### PR TITLE
ProtobufWritable needs zero-arg constructor 

### DIFF
--- a/src/java/com/twitter/elephantbird/mapreduce/io/ProtobufWritable.java
+++ b/src/java/com/twitter/elephantbird/mapreduce/io/ProtobufWritable.java
@@ -13,6 +13,8 @@ import com.twitter.elephantbird.util.TypeRef;
 public class ProtobufWritable<M extends Message> extends BinaryWritable<M> {
   private static final Logger LOG = LoggerFactory.getLogger(ProtobufWritable.class);
 
+  public ProtobufWritable() {}
+
   public ProtobufWritable(TypeRef<M> typeRef) {
     this(null, typeRef);
   }


### PR DESCRIPTION
ProtobufWritable needs a zero-arg constructor to be properly instantiated by Hadoop.  Check out:
http://hadoop-jt.slc1.twitter.com:50030/jobfailures.jsp?jobid=job_201101121741_44440&kind=reduce&cause=failed

java.lang.RuntimeException: java.lang.NoSuchMethodException: com.twitter.elephantbird.mapreduce.io.ProtobufWritable.()
    at org.apache.hadoop.util.ReflectionUtils.newInstance(ReflectionUtils.java:115)
    at org.apache.hadoop.io.serializer.WritableSerialization$WritableDeserializer.deserialize(WritableSerialization.java:62)
    at org.apache.hadoop.io.serializer.WritableSerialization$WritableDeserializer.deserialize(WritableSerialization.java:40)
    at org.apache.hadoop.mapreduce.ReduceContext.nextKeyValue(ReduceContext.java:116)
    at org.apache.hadoop.mapreduce.ReduceContext.nextKey(ReduceContext.java:92)
    at org.apache.hadoop.mapreduce.Reducer.run(Reducer.java:175)
    at org.apache.hadoop.mapred.ReduceTask.runNewReducer(ReduceTask.java:566)
    at org.apache.hadoop.mapred.ReduceTask.run(ReduceTask.java:408)
    at org.apache.hadoop.mapred.Child.main(Child.java:170)
Caused by: java.lang.NoSuchMethodException: com.twitter.elephantbird.mapreduce.io.ProtobufWritable.()
    at java.lang.Class.getConstructor0(Class.java:2706)
    at java.lang.Class.getDeclaredConstructor(Class.java:1985)
    at org.apache.hadoop.util.ReflectionUtils.newInstance(ReflectionUtils.java:109)
    ... 8 more
