### PR TITLE
BinaryWritable toString

### DIFF
--- a/src/java/com/twitter/elephantbird/mapreduce/io/BinaryWritable.java
+++ b/src/java/com/twitter/elephantbird/mapreduce/io/BinaryWritable.java
@@ -98,5 +98,13 @@ public abstract class BinaryWritable<M> implements WritableComparable<BinaryWrit
   public int hashCode() {
     return 31 + ((message == null) ? 0 : message.hashCode());
   }
+  
+  @Override
+  public String toString() {
+    if (message == null) {
+      return super.toString();
+    }
+    return message.toString();
+  }
 
 }


### PR DESCRIPTION
Added a toString to the BinaryWritable class. Very useful for when mockito tests compares two writables, now it will actually let the developer know what the difference between them were.
