### PR TITLE
Default zero-arg constructor for ProtobufWritable and ThriftWritable.

### DIFF
--- a/examples/protoc-gen-piglet
+++ b/examples/protoc-gen-piglet
@@ -1,1 +1,2 @@
-/usr/bin/java -cp ../lib/*:../dist/elephant-bird-1.0.jar:dist/elephant-bird-examples-1.0.jar com.twitter.elephantbird.proto.HadoopProtoCodeGenerator config-piglet.yml -
+for f in ../dist/elephant-bird-*.jar; do JAR=$f; done
+/usr/bin/java -cp ../lib/*:$JAR:dist/elephant-bird-examples-1.0.jar com.twitter.elephantbird.proto.HadoopProtoCodeGenerator config-piglet.yml -

--- a/examples/protoc-gen-twadoop
+++ b/examples/protoc-gen-twadoop
@@ -1,1 +1,2 @@
-/usr/bin/java -cp ../lib/*:../dist/elephant-bird-1.0.jar com.twitter.elephantbird.proto.HadoopProtoCodeGenerator config-twadoop.yml -
+for f in ../dist/elephant-bird-*.jar; do JAR=$f; done
+/usr/bin/java -cp ../lib/*:$JAR com.twitter.elephantbird.proto.HadoopProtoCodeGenerator config-twadoop.yml -

--- a/examples/src/java/com/twitter/elephantbird/examples/ThriftMRExample.java
+++ b/examples/src/java/com/twitter/elephantbird/examples/ThriftMRExample.java
@@ -10,6 +10,7 @@ import org.apache.hadoop.io.NullWritable;
 import org.apache.hadoop.io.Text;
 import org.apache.hadoop.mapreduce.Job;
 import org.apache.hadoop.mapreduce.Mapper;
+import org.apache.hadoop.mapreduce.Reducer;
 import org.apache.hadoop.mapreduce.lib.input.FileInputFormat;
 import org.apache.hadoop.mapreduce.lib.input.TextInputFormat;
 import org.apache.hadoop.mapreduce.lib.output.FileOutputFormat;
@@ -24,10 +25,10 @@ import com.twitter.elephantbird.mapreduce.output.LzoThriftB64LineOutputFormat;
 import com.twitter.elephantbird.mapreduce.output.LzoThriftBlockOutputFormat;
 
 /**
- * -Dthrift.test=lzoOut : takes text files with name and age on each line as 
+ * -Dthrift.test=lzoOut : takes text files with name and age on each line as
  * input and writes to lzo file with Thrift serilized data. <br>
  * -Dthrift.test=lzoIn : does the reverse. <br><br>
- * 
+ *
  * -Dthrift.test.format=Block (or B64Line) to test different formats. <br>
  */
 
@@ -38,7 +39,7 @@ public class ThriftMRExample {
   public static class TextMapper extends Mapper<LongWritable, Text, NullWritable, ThriftWritable<Age>> {
     ThriftWritable<Age> tWritable = ThriftWritable.newInstance(Age.class);
     Age age = new Age();
-    
+
     @Override
     protected void map(LongWritable key, Text value, Context context) throws IOException, InterruptedException {
       StringTokenizer line = new StringTokenizer(value.toString(), "\t\r\n");
@@ -59,7 +60,7 @@ public class ThriftMRExample {
     job.setJarByClass(getClass());
     job.setMapperClass(TextMapper.class);
     job.setNumReduceTasks(0);
-    
+
     job.setInputFormatClass(TextInputFormat.class);
     if (conf.get("thrift.test.format", "B64Line").equals("Block")) {
       job.setOutputFormatClass(LzoThriftBlockOutputFormat.getOutputFormatClass(Age.class, job.getConfiguration()));
@@ -73,7 +74,7 @@ public class ThriftMRExample {
     return job.waitForCompletion(true) ? 0 : 1;
   }
 
-  
+
   public static class LzoMapper extends Mapper<LongWritable, ThriftWritable<Age>, Text, Text> {
     @Override
     protected void map(LongWritable key, ThriftWritable<Age> value, Context context) throws IOException, InterruptedException {
@@ -89,12 +90,67 @@ public class ThriftMRExample {
     job.setJarByClass(getClass());
     job.setMapperClass(LzoMapper.class);
     job.setNumReduceTasks(0);
-    
+
     if (conf.get("thrift.test.format", "B64Line").equals("Block")) {
       job.setInputFormatClass(LzoThriftBlockInputFormat.getInputFormatClass(Age.class, job.getConfiguration()));
     } else {
-      job.setInputFormatClass(LzoThriftB64LineInputFormat.getInputFormatClass(Age.class, job.getConfiguration()));      
+      job.setInputFormatClass(LzoThriftB64LineInputFormat.getInputFormatClass(Age.class, job.getConfiguration()));
     }
+    job.setOutputFormatClass(TextOutputFormat.class);
+
+    FileInputFormat.setInputPaths(job, new Path(args[0]));
+    FileOutputFormat.setOutputPath(job, new Path(args[1]));
+
+    return job.waitForCompletion(true) ? 0 : 1;
+  }
+
+  public static class SortMapper extends Mapper<LongWritable, Text, Text, ThriftWritable<Age>> {
+    ThriftWritable<Age> tWritable = ThriftWritable.newInstance(Age.class);
+    Age age = new Age();
+
+    @Override
+    protected void map(LongWritable key, Text value, Context context) throws IOException, InterruptedException {
+      StringTokenizer line = new StringTokenizer(value.toString(), "\t\r\n");
+
+      if (line.hasMoreTokens()
+          && age.setName(line.nextToken()) != null
+          && line.hasMoreTokens()
+          && age.setAge(Integer.parseInt(line.nextToken())) != null) {
+          tWritable.set(age);
+          context.write(new Text(age.getName()), tWritable);
+      }
+    }
+  }
+
+  public static class SortReducer extends Reducer<Text, ThriftWritable<Age>, Text, Text> {
+    @Override
+    protected void reduce(Text key, Iterable<ThriftWritable<Age>> values, Context context) throws IOException, InterruptedException {
+      for(ThriftWritable<Age> value : values) {
+        /* setConverter() before get() is required since 'value' object was
+         * created by MR with default ThriftWritable's default constructor,
+         * as result object does not know its runtime Thrift class.
+         */
+        value.setConverter(Age.class);
+        context.write(null, new Text(value.get().getName() + "\t" + value.get().getAge()));
+      }
+    }
+  }
+
+  int runSorter(String[] args, Configuration conf) throws Exception {
+    //A more complete example with reducers. Tests ThriftWritable as
+    //map output value class.
+    Job job = new Job(conf);
+    job.setJobName("Thift Example : ThriftWritable as Map output class");
+
+    job.setJarByClass(getClass());
+    job.setMapperClass(SortMapper.class);
+    job.setMapOutputKeyClass(Text.class);
+    job.setMapOutputValueClass(ThriftWritable.class);
+
+    job.setReducerClass(SortReducer.class);
+    job.setNumReduceTasks(1);
+
+    job.setInputFormatClass(TextInputFormat.class);
     job.setOutputFormatClass(TextOutputFormat.class);
 
     FileInputFormat.setInputPaths(job, new Path(args[0]));
@@ -107,17 +163,19 @@ public class ThriftMRExample {
     Configuration conf = new Configuration();
     args = new GenericOptionsParser(conf, args).getRemainingArgs();
     ThriftMRExample runner = new ThriftMRExample();
-    
+
     if (args.length != 2) {
       System.out.println("Usage: hadoop jar path/to/this.jar " + runner.getClass() + " <input dir> <output dir>");
       System.exit(1);
     }
-    
+
     String test = conf.get("thrift.test", "lzoIn");
-    
+
     if (test.equals("lzoIn"))
       System.exit(runner.runLzoToText(args, conf));
     if (test.equals("lzoOut"))
       System.exit(runner.runTextToLzo(args, conf));
+    if (test.equals("sort"))
+      System.exit(runner.runSorter(args, conf));
   }
 }

--- a/src/java/com/twitter/elephantbird/mapreduce/io/BinaryWritable.java
+++ b/src/java/com/twitter/elephantbird/mapreduce/io/BinaryWritable.java
@@ -18,35 +18,85 @@ public abstract class BinaryWritable<M> implements WritableComparable<BinaryWrit
   private static final Logger LOG = LoggerFactory.getLogger(BinaryWritable.class);
 
   private M message;
-  private final BinaryConverter<M> converter;
+  private byte[] messageBytes; // deserialization is delayed till get()
+  private BinaryConverter<M> converter;
 
   protected BinaryWritable(M message, BinaryConverter<M> converter) {
     this.message = message;
     this.converter = converter;
   }
 
+  /** throws an exception if the converter is not set */
+  private void checkConverter() {
+    if (converter == null) {
+      throw new IllegalStateException("Runtime parameterized Protobuf/Thrift class is unkonwn. " +
+                                      "This object was probably created with default constructor. " +
+                                      "Please use setConverter(Class).");
+    }
+  }
+
+  protected abstract BinaryConverter<M> getConverterFor(Class<M> clazz);
+
+  /**
+   * Sets the handler for serialization and deserialization based on the class.
+   * This converter is often set in constructor. But some times it might be
+   * impossible to know the the actual class during construction. <br> <br>
+   *
+   * E.g. when this writable is used as output value for a Mapper,
+   * MR creates writable on the Reducer using the default constructor,
+   * and there is no way for us to know the parameterized class.
+   * In this case, user invokes setConverter() before
+   * calling get() to supply parameterized class. <br>
+   *
+   * The class name could be written as part of writable serialization, but we
+   * don't yet see a need to do that as it has many other disadvantages.
+   */
+  public void setConverter(Class<M> clazz) {
+    converter = getConverterFor(clazz);
+  }
+
+  /**
+   * Returns the current object. <br>
+   * The desirialazion of the actual Protobuf/Thrift object is delayed till
+   * the first call to this method. <br>
+   * In some cases the the parameterized proto class may not be known yet
+   * ( in case of default construction. see {@link #setConverter(Class)} ),
+   * and this will throw an {@link IllegalStateException}.
+   */
   public M get() {
+    if (messageBytes != null) {
+      checkConverter();
+      message = converter.fromBytes(messageBytes);
+      messageBytes = null;
+    }
     return message;
   }
 
   public void clear() {
     message = null;
+    messageBytes = null;
   }
 
   public void set(M message) {
     this.message = message;
+    messageBytes = null;
   }
 
   @Override
   public void write(DataOutput out) throws IOException {
     byte[] bytes = null;
+
     if (message != null) {
+      checkConverter();
       bytes = converter.toBytes(message);
       if (bytes == null) {
         // should we throw an IOException instead?
         LOG.warn("Could not serialize " + message.getClass());
       }
+    } else if (messageBytes != null) {
+      bytes = messageBytes;
     }
+
     if (bytes != null) {
       out.writeInt(bytes.length);
       out.write(bytes, 0, bytes.length);
@@ -59,16 +109,24 @@ public abstract class BinaryWritable<M> implements WritableComparable<BinaryWrit
   public void readFields(DataInput in) throws IOException {
     int size = in.readInt();
     if (size > 0) {
-      byte[] messageBytes = new byte[size];
+      messageBytes = new byte[size];
       in.readFully(messageBytes, 0, size);
-      message = converter.fromBytes(messageBytes);
+      // messageBytes is deserialized in get().
     }
   }
 
   @Override
   public int compareTo(BinaryWritable<M> other) {
-    byte[] bytes = converter.toBytes(message);
-    byte[] otherBytes = converter.toBytes(other.get());
+    byte[] bytes = messageBytes;
+    if (message != null) {
+      checkConverter();
+      bytes = converter.toBytes(message);
+    }
+    byte[] otherBytes = other.messageBytes;
+    if (other.message != null) {
+      other.checkConverter();
+      otherBytes = other.converter.toBytes(other.message);
+    }
     return BytesWritable.Comparator.compareBytes(bytes, 0, bytes.length, otherBytes, 0, otherBytes.length);
   }
 

--- a/src/java/com/twitter/elephantbird/mapreduce/io/ProtobufWritable.java
+++ b/src/java/com/twitter/elephantbird/mapreduce/io/ProtobufWritable.java
@@ -1,8 +1,5 @@
 package com.twitter.elephantbird.mapreduce.io;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import com.google.protobuf.Message;
 import com.twitter.elephantbird.util.TypeRef;
 
@@ -11,7 +8,10 @@ import com.twitter.elephantbird.util.TypeRef;
  */
 
 public class ProtobufWritable<M extends Message> extends BinaryWritable<M> {
-  private static final Logger LOG = LoggerFactory.getLogger(ProtobufWritable.class);
+
+  public ProtobufWritable() {
+    super(null, null);
+  }
 
   public ProtobufWritable(TypeRef<M> typeRef) {
     this(null, typeRef);
@@ -19,14 +19,17 @@ public class ProtobufWritable<M extends Message> extends BinaryWritable<M> {
 
   public ProtobufWritable(M message, TypeRef<M> typeRef) {
     super(message, new ProtobufConverter<M>(typeRef));
-    LOG.debug("ProtobufWritable, typeClass is " + typeRef.getRawClass());
   }
 
   /**
-   * Returns a ThriftWritable for a given Thrift class.
+   * Returns a ProtobufWritable for a given Protobuf class.
    */
   public static <M extends Message> ProtobufWritable<M> newInstance(Class<M> tClass) {
     return new ProtobufWritable<M>(new TypeRef<M>(tClass){});
   }
 
+  @Override
+  protected BinaryConverter<M> getConverterFor(Class<M> clazz) {
+    return ProtobufConverter.newInstance(clazz);
+  }
 }

--- a/src/java/com/twitter/elephantbird/mapreduce/io/ThriftWritable.java
+++ b/src/java/com/twitter/elephantbird/mapreduce/io/ThriftWritable.java
@@ -1,30 +1,34 @@
 package com.twitter.elephantbird.mapreduce.io;
 
 import org.apache.thrift.TBase;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import com.twitter.elephantbird.util.TypeRef;
 
 /**
- * {@link BinaryWritable} for Thrift 
+ * {@link BinaryWritable} for Thrift
  */
 public class ThriftWritable<M extends TBase<?>> extends BinaryWritable<M> {
-  private static final Logger LOG = LoggerFactory.getLogger(ThriftWritable.class);
-  
   /**
    * Returns a ThriftWritable for a given Thrift class.
    */
   public static <M extends TBase<?>> ThriftWritable<M> newInstance(Class<M> tClass) {
     return new ThriftWritable<M>(new TypeRef<M>(tClass){});
   }
-  
+
+  public ThriftWritable() {
+    super(null, null);
+  }
+
   public ThriftWritable(TypeRef<M> typeRef) {
     this(null, typeRef);
   }
 
   public ThriftWritable(M message, TypeRef<M> typeRef) {
     super(message, new ThriftConverter<M>(typeRef));
-    LOG.debug("TProtoWritable, typeClass is " + typeRef.getRawClass());
+  }
+
+  @Override
+  protected BinaryConverter<M> getConverterFor(Class<M> clazz) {
+    return ThriftConverter.newInstance(clazz);
   }
 }


### PR DESCRIPTION
These writables didn't have zero-arg constructor, but it is required in many cases. e.g. when used as Mapper's output class. Since a default constructor does not have enough info (it does not know which Thrift/Protobuf class is being deserialized), we delay full deserialization till user wants to access the proto object with get().

*MRExamples.java is updated to trigger this case.

more discusion on earlier pull request : https://github.com/kevinweil/elephant-bird/pull/22
