### PR TITLE
ThriftToPig fails with 'required' fields.

### DIFF
--- a/src/java/com/twitter/elephantbird/pig/piggybank/ThriftToPig.java
+++ b/src/java/com/twitter/elephantbird/pig/piggybank/ThriftToPig.java
@@ -1,5 +1,6 @@
 package com.twitter.elephantbird.pig.piggybank;
 
+import java.lang.reflect.Field;
 import java.util.ArrayDeque;
 import java.util.Deque;
 import java.util.HashMap;
@@ -713,12 +714,12 @@ public class ThriftToPig<M extends TBase<?>> {
   public static String toPigScript(Class<? extends TBase<?>> thriftClass,
                                    Class<? extends LoadFunc> pigLoader) {
     StringBuilder sb = new StringBuilder();
-    /* we are commenting out explicit schema specification. The schema is 
-     * included mainly to help the readers of the pig script. Pig learns the 
-     * schema directly from the loader. 
+    /* we are commenting out explicit schema specification. The schema is
+     * included mainly to help the readers of the pig script. Pig learns the
+     * schema directly from the loader.
      * If explicit schema is not commented, we might have surprising results
-     * when a Thrift class (possibly in control of another team) changes, 
-     * but the Pig script is not updated. Commenting it out work around this. 
+     * when a Thrift class (possibly in control of another team) changes,
+     * but the Pig script is not updated. Commenting it out work around this.
      */
     StringBuilder prefix = new StringBuilder("       --  ");
     sb.append("raw_data = load '$INPUT_FILES' using ")
@@ -821,27 +822,17 @@ public class ThriftToPig<M extends TBase<?>> {
       }
   }
 
-
-  private class TProtoForStruct extends ThriftProtocol {
-    // essentially a hack to get to STRUCT_DESC in a Thrift class
-    TStruct structDesc;
-    public void writeStructBegin(TStruct struct) throws TException {
-      structDesc = struct;
-      throw new TException("expected");
-    }
-  }
-
   private TStruct getStructDesc(Class<? extends TBase<?>> tClass) {
-    // hack to get hold of STRUCT_DESC of a thrift class :
-    // writeStructBegin() uses this descriptor.
-    TProtoForStruct proto = new TProtoForStruct();
+    // hack to get hold of STRUCT_DESC of a thrift class:
+    // Access 'private static final' field STRUCT_DESC using reflection.
+    // Bad practice, but not sure if there is a better way.
     try {
-      tClass.newInstance().write(proto);
-    } catch (TException e) {
+      Field f = tClass.getDeclaredField("STRUCT_DESC");
+      f.setAccessible(true);
+      return (TStruct) f.get(null);
     } catch (Throwable t) {
       throw new RuntimeException(t);
     }
-    return proto.structDesc;
   }
 
   public static void main(String[] args) throws Exception {


### PR DESCRIPTION
The existing method of accessing 'STRUCT_DESC' field of a Thrift class does not work if Thrift class has non-primitive required fields. It depended on invoking write() method on an object.

This patch uses reflection to access this field. Surprisingly Java allows access even for a 'private static'. 
