### PR TITLE
Update to Writables (issue #28)

### DIFF
--- a/src/java/com/twitter/elephantbird/mapreduce/io/ProtobufWritable.java
+++ b/src/java/com/twitter/elephantbird/mapreduce/io/ProtobufWritable.java
@@ -1,7 +1,5 @@
 package com.twitter.elephantbird.mapreduce.io;
 
-import java.util.Arrays;
-
 import com.google.protobuf.Message;
 import com.twitter.elephantbird.util.TypeRef;
 
@@ -33,17 +31,5 @@ public class ProtobufWritable<M extends Message> extends BinaryWritable<M> {
   @Override
   protected BinaryConverter<M> getConverterFor(Class<M> clazz) {
     return ProtobufConverter.newInstance(clazz);
-  }
-
-  /**
-   * <p>Returns a hashCode that is stable across multiple instances of JVMs.
-   * (<code>hashCode()</code> is not required to return the same value in
-   * different instances of the same applications in Java, just in a
-   * single instance of the application; Hadoop imposes a more strict requirement.)
-   */
-  @Override
-  public int hashCode() {
-    byte[] bytes = serialize();
-    return (bytes == null) ? 31 : Arrays.hashCode(bytes);
   }
 }


### PR DESCRIPTION
This is continuation of issue #28 ( https://github.com/kevinweil/elephant-bird/issues#issue/28 ).

BinaryWritable keeps the serialized buffer most of the time.. at any time either proto object or buffer is non-null.
- removed serialized and deserialized boolean variables.
- equals() is now consistent with hashCode() and compareTo().
