### PR TITLE
B64Line Pig loaders

### DIFF
--- a/src/java/com/twitter/elephantbird/pig/load/LzoBinaryB64LinePigLoader.java
+++ b/src/java/com/twitter/elephantbird/pig/load/LzoBinaryB64LinePigLoader.java
@@ -1,0 +1,74 @@
+package com.twitter.elephantbird.pig.load;
+
+import java.io.IOException;
+import java.nio.charset.Charset;
+
+import org.apache.commons.codec.binary.Base64;
+import org.apache.pig.data.Tuple;
+import org.apache.pig.impl.util.Pair;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.twitter.elephantbird.mapreduce.io.BinaryConverter;
+
+/**
+ * This is the base class for all base64 encoded, line-oriented
+ * pig loaders for protocol buffers, Thrift etc.
+ * Data is expected to be one base64 encoded serialized object per line.
+ */
+
+public abstract class LzoBinaryB64LinePigLoader extends LzoBaseLoadFunc {
+  private static final Logger LOG = LoggerFactory.getLogger(LzoBinaryB64LinePigLoader.class);
+
+  private BinaryConverter<Tuple> tupleConverter_ = null;
+  private final Base64 base64_ = new Base64();
+
+  private static final Charset UTF8 = Charset.forName("UTF-8");
+  private static final byte RECORD_DELIMITER = (byte)'\n';
+
+  private Pair<String, String> linesRead;
+  private Pair<String, String> recordsRead;
+  private Pair<String, String> errors;
+
+  /**
+   * className is used for naming counters.
+   */
+  protected void init(String className, BinaryConverter<Tuple> tupleConverter) {
+    tupleConverter_ = tupleConverter;
+    String group = "LzoB64Lines of " + className;
+    linesRead = new Pair<String, String>(group, "Lines Read");
+    recordsRead = new Pair<String, String>(group, "Records Read");
+    errors = new Pair<String, String>(group, "Errors");
+  }
+
+  public void skipToNextSyncPoint(boolean atFirstRecord) throws IOException {
+    // Since we are not block aligned we throw away the first (mostly partial)
+    // line of each split and count on a different
+    // instance to read it. The only split this doesn't work for is the first.
+    if (!atFirstRecord && verifyStream()) {
+      is_.readLine(UTF8, RECORD_DELIMITER);
+      // don't increment linesRead either.
+    }
+  }
+
+  /**
+   * Return every non-null line as a single-element tuple to Pig.
+   */
+  public Tuple getNext() throws IOException {
+    String line;
+    Tuple t = null;
+
+    while (verifyStream() && (line = is_.readLine(UTF8, RECORD_DELIMITER)) != null) {
+      incrCounter(linesRead, 1L);
+      t = tupleConverter_.fromBytes(base64_.decode(line.getBytes(UTF8)));
+      if (t != null) {
+        incrCounter(recordsRead, 1L);
+        break;
+      } else {
+        incrCounter(errors, 1L);
+      }
+    }
+
+    return t;
+  }
+}

--- a/src/java/com/twitter/elephantbird/pig/load/LzoProtobufB64LinePigLoader.java
+++ b/src/java/com/twitter/elephantbird/pig/load/LzoProtobufB64LinePigLoader.java
@@ -1,19 +1,15 @@
 package com.twitter.elephantbird.pig.load;
 
 import java.io.IOException;
-import java.nio.charset.Charset;
-
-import org.apache.commons.codec.binary.Base64;
 import org.apache.pig.ExecType;
 import org.apache.pig.backend.datastorage.DataStorage;
 import org.apache.pig.data.Tuple;
 import org.apache.pig.impl.logicalLayer.schema.Schema;
-import org.apache.pig.impl.util.Pair;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.google.common.base.Function;
 import com.google.protobuf.Message;
+import com.twitter.elephantbird.mapreduce.io.BinaryConverter;
 import com.twitter.elephantbird.mapreduce.io.ProtobufConverter;
 import com.twitter.elephantbird.pig.util.ProtobufToPig;
 import com.twitter.elephantbird.pig.util.ProtobufTuple;
@@ -21,26 +17,17 @@ import com.twitter.elephantbird.util.Protobufs;
 import com.twitter.elephantbird.util.TypeRef;
 
 /**
- * This is the base class for all base64 encoded, line-oriented protocol buffer based pig loaders.
+ * This is the class for all base64 encoded, line-oriented protocol buffer based pig loaders.
  * Data is expected to be one base64 encoded serialized protocol buffer per line. The specific
  * protocol buffer is a template parameter, generally specified by a codegen'd derived class.
  * See com.twitter.elephantbird.proto.HadoopProtoCodeGenerator.
  */
 
-public class LzoProtobufB64LinePigLoader<M extends Message> extends LzoBaseLoadFunc {
+public class LzoProtobufB64LinePigLoader<M extends Message> extends LzoBinaryB64LinePigLoader {
   private static final Logger LOG = LoggerFactory.getLogger(LzoProtobufB64LinePigLoader.class);
 
   private TypeRef<M> typeRef_ = null;
   private ProtobufConverter<M> protoConverter_ = null;
-  private final Base64 base64_ = new Base64();
-  private final ProtobufToPig protoToPig_ = new ProtobufToPig();
-
-  private static final Charset UTF8 = Charset.forName("UTF-8");
-  private static final byte RECORD_DELIMITER = (byte)'\n';
-
-  private Pair<String, String> linesRead;
-  private Pair<String, String> protobufsRead;
-  private Pair<String, String> protobufErrors;
 
   public LzoProtobufB64LinePigLoader() {
     LOG.info("LzoProtobufB64LineLoader zero-parameter creation");
@@ -60,52 +47,25 @@ public class LzoProtobufB64LinePigLoader<M extends Message> extends LzoBaseLoadF
   public void setTypeRef(TypeRef<M> typeRef) {
     typeRef_ = typeRef;
     protoConverter_ = ProtobufConverter.newInstance(typeRef);
-    String group = "LzoB64Lines of " + typeRef_.getRawClass().getName();
-    linesRead = new Pair<String, String>(group, "Lines Read");
-    protobufsRead = new Pair<String, String>(group, "Protobufs Read");
-    protobufErrors = new Pair<String, String>(group, "Errors");
-  }
-
-  public void skipToNextSyncPoint(boolean atFirstRecord) throws IOException {
-    // Since we are not block aligned we throw away the first record of each split and count on a different
-    // instance to read it.  The only split this doesn't work for is the first.
-    if (!atFirstRecord) {
-      getNext();
-    }
-  }
-
-  @Override
-  protected boolean verifyStream() throws IOException {
-    return is_ != null;
-  }
-
-  /**
-   * Return every non-null line as a single-element tuple to Pig.
-   */
-  public Tuple getNext() throws IOException {
-    if (!verifyStream()) {
-      return null;
-    }
-
-    String line;
-    Tuple t = null;
-    while ((line = is_.readLine(UTF8, RECORD_DELIMITER)) != null) {
-      incrCounter(linesRead, 1L);
-      M protoValue = protoConverter_.fromBytes(base64_.decode(line.getBytes("UTF-8")));
-      if (protoValue != null) {
-        t = new ProtobufTuple(protoValue);
-        incrCounter(protobufsRead, 1L);
-        break;
-      } else {
-        incrCounter(protobufErrors, 1L);
+    BinaryConverter<Tuple> converter = new BinaryConverter<Tuple>() {
+      public Tuple fromBytes(byte[] messageBuffer) {
+        Message message = protoConverter_.fromBytes(messageBuffer);
+        if (message != null) {
+          return new ProtobufTuple(message);
+        }
+        return null;
       }
-    }
 
-    return t;
+      public byte[] toBytes(Tuple message) {
+        throw new RuntimeException("not implemented");
+      }
+    };
+
+    init(typeRef_.getRawClass().getName(), converter);
   }
 
   @Override
   public Schema determineSchema(String filename, ExecType execType, DataStorage store) throws IOException {
-    return protoToPig_.toSchema(Protobufs.getMessageDescriptor(typeRef_.getRawClass()));
+    return new ProtobufToPig().toSchema(Protobufs.getMessageDescriptor(typeRef_.getRawClass()));
   }
 }

--- a/src/java/com/twitter/elephantbird/pig/load/LzoThriftB64LinePigLoader.java
+++ b/src/java/com/twitter/elephantbird/pig/load/LzoThriftB64LinePigLoader.java
@@ -1,91 +1,57 @@
 package com.twitter.elephantbird.pig.load;
 
 import java.io.IOException;
-import java.nio.charset.Charset;
 
-import org.apache.commons.codec.binary.Base64;
 import org.apache.pig.ExecType;
 import org.apache.pig.backend.datastorage.DataStorage;
 import org.apache.pig.data.Tuple;
 import org.apache.pig.impl.logicalLayer.schema.Schema;
-import org.apache.pig.impl.util.Pair;
 import org.apache.thrift.TBase;
 import org.apache.thrift.TException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.twitter.elephantbird.mapreduce.io.BinaryConverter;
 import com.twitter.elephantbird.mapreduce.io.ThriftConverter;
 import com.twitter.elephantbird.pig.util.ThriftToPig;
 import com.twitter.elephantbird.util.ThriftUtils;
 import com.twitter.elephantbird.util.TypeRef;
 
-public class LzoThriftB64LinePigLoader<M extends TBase<?, ?>> extends LzoBaseLoadFunc {
+/**
+ * Loader for LZO files with line-oriented base64 encoded Thrift objects.
+ */
+public class LzoThriftB64LinePigLoader<M extends TBase<?, ?>> extends LzoBinaryB64LinePigLoader {
   private static final Logger LOG = LoggerFactory.getLogger(LzoThriftB64LinePigLoader.class);
 
   private final TypeRef<M> typeRef_;
-  private final ThriftConverter<M> converter_;
-  private final Base64 base64_ = new Base64();
+  private ThriftConverter<M> converter_;
   private final ThriftToPig<M> thriftToPig_;
-
-  private static final Charset UTF8 = Charset.forName("UTF-8");
-  private static final byte RECORD_DELIMITER = (byte)'\n';
-
-  private Pair<String, String> linesRead;
-  private Pair<String, String> thriftStructsRead;
-  private Pair<String, String> thriftErrors;
 
   public LzoThriftB64LinePigLoader(String thriftClassName) {
     typeRef_ = ThriftUtils.getTypeRef(thriftClassName);
     converter_ = ThriftConverter.newInstance(typeRef_);
     thriftToPig_ =  ThriftToPig.newInstance(typeRef_);
 
-    String group = "LzoB64Lines of " + typeRef_.getRawClass().getName();
-    linesRead = new Pair<String, String>(group, "Lines Read");
-    thriftStructsRead = new Pair<String, String>(group, "Thrift Structs");
-    thriftErrors = new Pair<String, String>(group, "Errors");
-
-    setLoaderSpec(getClass(), new String[]{thriftClassName});
-  }
-
-  public void skipToNextSyncPoint(boolean atFirstRecord) throws IOException {
-    // Since we are not block aligned we throw away the first record of each split and count on a different
-    // instance to read it.  The only split this doesn't work for is the first.
-    if (!atFirstRecord) {
-      getNext();
-    }
-  }
-
-  @Override
-  protected boolean verifyStream() throws IOException {
-    return is_ != null;
-  }
-
-  /**
-   * Return every non-null line as a single-element tuple to Pig.
-   */
-  public Tuple getNext() throws IOException {
-    if (!verifyStream()) {
-      return null;
-    }
-
-    String line;
-    Tuple t = null;
-    while ((line = is_.readLine(UTF8, RECORD_DELIMITER)) != null) {
-      incrCounter(linesRead, 1L);
-      M value = converter_.fromBytes(base64_.decode(line.getBytes("UTF-8")));
-      if (value != null) {
-        try {
-          t = thriftToPig_.getPigTuple(value);
-          incrCounter(thriftStructsRead, 1L);
-          break;
-        } catch (TException e) {
-          incrCounter(thriftErrors, 1L);
-          LOG.warn("ThriftToTuple error :", e); // may be struct mismatch
+    BinaryConverter<Tuple> tupleConverter = new BinaryConverter<Tuple>() {
+      public Tuple fromBytes(byte[] messageBuffer) {
+        M value = converter_.fromBytes(messageBuffer);
+        if (value != null) {
+          try {
+            return thriftToPig_.getPigTuple(value);
+          } catch (TException e) {
+            LOG.warn("ThriftToTuple error :", e); // may be struct mismatch
+          }
         }
+        return null;
       }
-    }
 
-    return t;
+      public byte[] toBytes(Tuple message) {
+        throw new RuntimeException("not implemented");
+      }
+    };
+
+    init(thriftClassName, tupleConverter);
+    setLoaderSpec(getClass(), new String[]{thriftClassName});
   }
 
   @Override


### PR DESCRIPTION
- Pig loaders for Lzo B64Line files didn't stop reading at the end of their splits.
- also at the beginning of a split, they skipped first good serialized object, rather than skipping till first newline. this a each intermediate split lost one object.

Reorganized Lzo*B64LinePigLoaders so that Protobuf and Thrift reuse the code.

manually tested Protobufs. will test Thrift as well. 
