### PR TITLE
ThriftToPig : don't wrap STRUCT in containers with another tuple.

### DIFF
--- a/src/java/com/twitter/elephantbird/pig/util/ThriftToPig.java
+++ b/src/java/com/twitter/elephantbird/pig/util/ThriftToPig.java
@@ -264,8 +264,9 @@ public class ThriftToPig<M extends TBase<?, ?>> {
 
     switch (field.getType()) {
       case TType.STRUCT:
-        fieldSchema = new FieldSchema(fieldName, toSchema(field.gettStructDescriptor()), DataType.TUPLE);
-        break;
+        // wrapping STRUCT in a FieldSchema makes it impossible to
+        // access fields in PIG script (causes runtime error).
+        return toSchema(field.gettStructDescriptor());
       case TType.LIST:
         fieldSchema = singleFieldToFieldSchema(fieldName, field.getListElemField());
         break;


### PR DESCRIPTION
Thirft IDL:

`struct Person {
     1: string name
}
struct Members {
    1: list<Person> persons;
}`

Pig Schema for Members currently : 

`( persons : { persons_tuple : (name : chararray) }`

But this causes runtime errors when we try to access persons_tuple.name. This is mismatch between generated schema and how he Thrift objects are deserialized into tuples. 
This patch changes the schema to : 

`( persons : { name : string } )`
