### PR TITLE
Fix input and output format initialization for Thrift and Protobuf loaders and storage.

### DIFF
--- a/src/java/com/twitter/elephantbird/mapreduce/input/LzoThriftB64LineInputFormat.java
+++ b/src/java/com/twitter/elephantbird/mapreduce/input/LzoThriftB64LineInputFormat.java
@@ -24,7 +24,13 @@ import com.twitter.elephantbird.util.TypeRef;
 public class LzoThriftB64LineInputFormat<M extends TBase<?, ?>>
                 extends LzoInputFormat<LongWritable, ThriftWritable<M>> {
 
+  private TypeRef<M> typeRef_;
+
   public LzoThriftB64LineInputFormat() {}
+
+  public LzoThriftB64LineInputFormat(TypeRef<M> typeRef) {
+    typeRef_ = typeRef;
+  }
 
   /**
    * Returns {@link LzoThriftB64LineInputFormat} class for setting up a job.
@@ -41,8 +47,10 @@ public class LzoThriftB64LineInputFormat<M extends TBase<?, ?>>
   public RecordReader<LongWritable, ThriftWritable<M>> createRecordReader(InputSplit split,
       TaskAttemptContext taskAttempt) throws IOException, InterruptedException {
 
-    TypeRef<M> typeRef = ThriftUtils.getTypeRef(taskAttempt.getConfiguration(), LzoThriftB64LineInputFormat.class);
-    return new LzoThriftB64LineRecordReader<M>(typeRef);
+    if (typeRef_ == null) {
+      typeRef_ = ThriftUtils.getTypeRef(taskAttempt.getConfiguration(), LzoThriftB64LineInputFormat.class);
+    }
+    return new LzoThriftB64LineRecordReader<M>(typeRef_);
   }
 
 }

--- a/src/java/com/twitter/elephantbird/mapreduce/input/LzoThriftBlockInputFormat.java
+++ b/src/java/com/twitter/elephantbird/mapreduce/input/LzoThriftBlockInputFormat.java
@@ -24,7 +24,13 @@ public class LzoThriftBlockInputFormat<M extends TBase<?, ?>>
                 extends LzoInputFormat<LongWritable, ThriftWritable<M>> {
   // implementation is exactly same as LzoThriftB64LineINputFormat
 
+  private TypeRef<M> typeRef_;
+
   public LzoThriftBlockInputFormat() {}
+
+  public LzoThriftBlockInputFormat(TypeRef<M> typeRef) {
+    typeRef_ = typeRef;
+  }
 
   /**
    * Returns {@link LzoThriftBlockInputFormat} class for setting up a job.
@@ -41,9 +47,10 @@ public class LzoThriftBlockInputFormat<M extends TBase<?, ?>>
   @Override
   public RecordReader<LongWritable, ThriftWritable<M>> createRecordReader(InputSplit split,
       TaskAttemptContext taskAttempt) throws IOException, InterruptedException {
-
-    TypeRef<M> typeRef = ThriftUtils.getTypeRef(taskAttempt.getConfiguration(), LzoThriftBlockInputFormat.class);
-    return new LzoThriftBlockRecordReader<M>(typeRef);
+    if (typeRef_ == null) {
+      typeRef_ = ThriftUtils.getTypeRef(taskAttempt.getConfiguration(), LzoThriftBlockInputFormat.class);
+    }
+    return new LzoThriftBlockRecordReader<M>(typeRef_);
   }
 
 }

--- a/src/java/com/twitter/elephantbird/mapreduce/output/LzoProtobufB64LineOutputFormat.java
+++ b/src/java/com/twitter/elephantbird/mapreduce/output/LzoProtobufB64LineOutputFormat.java
@@ -30,6 +30,10 @@ public class LzoProtobufB64LineOutputFormat<M extends Message> extends LzoOutput
 
   public LzoProtobufB64LineOutputFormat() {}
 
+  public LzoProtobufB64LineOutputFormat(TypeRef<M> typeRef) {
+    typeRef_ = typeRef;
+  }
+
   /**
    * Returns {@link LzoProtobufBlockOutputFormat} class.
    * Sets an internal configuration in jobConf so that remote Tasks

--- a/src/java/com/twitter/elephantbird/mapreduce/output/LzoThriftB64LineOutputFormat.java
+++ b/src/java/com/twitter/elephantbird/mapreduce/output/LzoThriftB64LineOutputFormat.java
@@ -22,12 +22,12 @@ import org.apache.thrift.TBase;
 public class LzoThriftB64LineOutputFormat<M extends TBase<?, ?>>
     extends LzoOutputFormat<M, ThriftWritable<M>> {
 
-  protected TypeRef<M> typeRef;
+  protected TypeRef<M> typeRef_;
 
   public LzoThriftB64LineOutputFormat() {}
 
   public LzoThriftB64LineOutputFormat(TypeRef<M> typeRef) {
-    this.typeRef = typeRef;
+    typeRef_ = typeRef;
   }
 
   @SuppressWarnings("unchecked")
@@ -41,8 +41,9 @@ public class LzoThriftB64LineOutputFormat<M extends TBase<?, ?>>
   @Override
   public RecordWriter<NullWritable, ThriftWritable<M>> getRecordWriter(TaskAttemptContext job)
       throws IOException, InterruptedException {
-
-    TypeRef<M> typeRef = ThriftUtils.getTypeRef(job.getConfiguration(), LzoThriftB64LineOutputFormat.class);
-    return new LzoBinaryB64LineRecordWriter<M, ThriftWritable<M>>(new ThriftConverter<M>(typeRef), getOutputStream(job));
+    if (typeRef_ == null) {
+      typeRef_ = ThriftUtils.getTypeRef(job.getConfiguration(), LzoThriftB64LineOutputFormat.class);
+    }
+    return new LzoBinaryB64LineRecordWriter<M, ThriftWritable<M>>(new ThriftConverter<M>(typeRef_), getOutputStream(job));
   }
 }

--- a/src/java/com/twitter/elephantbird/mapreduce/output/LzoThriftBlockOutputFormat.java
+++ b/src/java/com/twitter/elephantbird/mapreduce/output/LzoThriftBlockOutputFormat.java
@@ -22,7 +22,13 @@ import org.apache.thrift.TBase;
 public class LzoThriftBlockOutputFormat<M extends TBase<?, ?>>
     extends LzoOutputFormat<M, ThriftWritable<M>> {
 
+  protected TypeRef<M> typeRef_;
+
   public LzoThriftBlockOutputFormat() {}
+
+  public LzoThriftBlockOutputFormat(TypeRef<M> typeRef) {
+    typeRef_ = typeRef;
+  }
 
   @SuppressWarnings("unchecked")
   public static <M extends TBase<?, ?>> Class<LzoThriftBlockOutputFormat>
@@ -34,9 +40,10 @@ public class LzoThriftBlockOutputFormat<M extends TBase<?, ?>>
 
   public RecordWriter<NullWritable, ThriftWritable<M>> getRecordWriter(TaskAttemptContext job)
       throws IOException, InterruptedException {
-
-    TypeRef<M> typeRef = ThriftUtils.getTypeRef(job.getConfiguration(), LzoThriftBlockOutputFormat.class);
+    if (typeRef_ == null) {
+      typeRef_ = ThriftUtils.getTypeRef(job.getConfiguration(), LzoThriftBlockOutputFormat.class);
+    }
     return new LzoBinaryBlockRecordWriter<M, ThriftWritable<M>>(
-        new ThriftBlockWriter<M>(getOutputStream(job), typeRef.getRawClass()));
+        new ThriftBlockWriter<M>(getOutputStream(job), typeRef_.getRawClass()));
   }
 }

--- a/src/java/com/twitter/elephantbird/pig/load/LzoBaseLoadFunc.java
+++ b/src/java/com/twitter/elephantbird/pig/load/LzoBaseLoadFunc.java
@@ -6,7 +6,6 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.mapreduce.Job;
 import org.apache.hadoop.mapreduce.RecordReader;
 import org.apache.hadoop.mapreduce.lib.input.FileInputFormat;
-import org.apache.pig.FuncSpec;
 import org.apache.pig.LoadFunc;
 import org.apache.pig.backend.hadoop.executionengine.mapReduceLayer.PigSplit;
 import org.apache.pig.impl.util.Pair;
@@ -28,9 +27,6 @@ public abstract class LzoBaseLoadFunc extends LoadFunc {
 
   protected RecordReader reader_;
 
-  // The load func spec is the load function name (with classpath) plus the arguments.
-  protected FuncSpec loadFuncSpec_;
-
   // Making accessing Hadoop counters from Pig slightly more convenient.
   private final PigCounterHelper counterHelper_ = new PigCounterHelper();
 
@@ -40,17 +36,6 @@ public abstract class LzoBaseLoadFunc extends LoadFunc {
    * Construct a new load func.
    */
   public LzoBaseLoadFunc() {
-    // By default, the spec is the class being loaded with no arguments.
-    setLoaderSpec(getClass(), new String[] {});
-  }
-
-  /**
-   * Set the loader spec so any arguments given in the script are tracked, to be reinstantiated by the mappers.
-   * @param clazz the class of the load function to use.
-   * @param args an array of strings that are fed to the class's constructor.
-   */
-  protected void setLoaderSpec(Class <? extends LzoBaseLoadFunc> clazz, String[] args) {
-    loadFuncSpec_ = new FuncSpec(clazz.getName(), args);
   }
 
   /**
@@ -86,5 +71,4 @@ public abstract class LzoBaseLoadFunc extends LoadFunc {
   public void prepareToRead(RecordReader reader, PigSplit split) {
       this.reader_ = reader;
   }
-
 }

--- a/src/java/com/twitter/elephantbird/pig/load/LzoProtobufB64LinePigLoader.java
+++ b/src/java/com/twitter/elephantbird/pig/load/LzoProtobufB64LinePigLoader.java
@@ -2,6 +2,7 @@ package com.twitter.elephantbird.pig.load;
 
 import java.io.IOException;
 
+import org.apache.hadoop.io.LongWritable;
 import org.apache.hadoop.mapreduce.InputFormat;
 import org.apache.hadoop.mapreduce.Job;
 import org.apache.pig.Expression;
@@ -50,7 +51,6 @@ public class LzoProtobufB64LinePigLoader<M extends Message> extends LzoBaseLoadF
   public LzoProtobufB64LinePigLoader(String protoClassName) {
     TypeRef<M> typeRef = PigUtil.getProtobufTypeRef(protoClassName);
     setTypeRef(typeRef);
-    setLoaderSpec(getClass(), new String[]{protoClassName});
   }
 
   /**
@@ -128,14 +128,12 @@ public class LzoProtobufB64LinePigLoader<M extends Message> extends LzoBaseLoadF
 
   }
 
-  @SuppressWarnings("rawtypes")
   @Override
-  public InputFormat getInputFormat() throws IOException {
+  public InputFormat<LongWritable, ProtobufWritable<M>> getInputFormat() throws IOException {
     if (typeRef_ == null) {
       LOG.error("Protobuf class must be specified before an InputFormat can be created. Do not use the no-argument constructor.");
       throw new IllegalArgumentException("Protobuf class must be specified before an InputFormat can be created. Do not use the no-argument constructor.");
     }
-    return LzoProtobufB64LineInputFormat.newInstance(typeRef_);
+    return new LzoProtobufB64LineInputFormat<M>(typeRef_);
   }
-
 }

--- a/src/java/com/twitter/elephantbird/pig/load/LzoProtobufBlockPigLoader.java
+++ b/src/java/com/twitter/elephantbird/pig/load/LzoProtobufBlockPigLoader.java
@@ -2,6 +2,7 @@ package com.twitter.elephantbird.pig.load;
 
 import java.io.IOException;
 
+import org.apache.hadoop.io.LongWritable;
 import org.apache.hadoop.mapreduce.InputFormat;
 import org.apache.hadoop.mapreduce.Job;
 import org.apache.pig.Expression;
@@ -50,7 +51,6 @@ public class LzoProtobufBlockPigLoader<M extends Message> extends LzoBaseLoadFun
   public LzoProtobufBlockPigLoader(String protoClassName) {
     TypeRef<M> typeRef = PigUtil.getProtobufTypeRef(protoClassName);
     setTypeRef(typeRef);
-    setLoaderSpec(getClass(), new String[]{protoClassName});
   }
 
   /**
@@ -118,13 +118,8 @@ public class LzoProtobufBlockPigLoader<M extends Message> extends LzoBaseLoadFun
   public void setPartitionFilter(Expression expr) throws IOException {
   }
 
-  @SuppressWarnings("rawtypes")
   @Override
-  public InputFormat getInputFormat() throws IOException {
-    if (typeRef_ == null) {
-      LOG.error("Protobuf class must be specified before an InputFormat can be created. Do not use the no-argument constructor.");
-      throw new IllegalArgumentException("Protobuf class must be specified before an InputFormat can be created. Do not use the no-argument constructor.");
-    }
-    return LzoProtobufBlockInputFormat.newInstance(typeRef_);
+  public InputFormat<LongWritable, ProtobufWritable<M>> getInputFormat() throws IOException {
+    return new LzoProtobufBlockInputFormat<M>(typeRef_);
   }
 }

--- a/src/java/com/twitter/elephantbird/pig/load/LzoRegexLoader.java
+++ b/src/java/com/twitter/elephantbird/pig/load/LzoRegexLoader.java
@@ -27,9 +27,6 @@ public class LzoRegexLoader extends LzoBaseRegexLoader {
   public LzoRegexLoader(String pattern) {
     LOG.info("LzoRegexLoader with regex = " + pattern);
 
-    // Store the constructor args so that individual slicers can recreate them.
-    setLoaderSpec(getClass(), new String[] { pattern } );
-
     pattern = pattern.replace("\\\\","\\");
     pattern_ = Pattern.compile(pattern);
   }

--- a/src/java/com/twitter/elephantbird/pig/load/LzoThriftB64LinePigLoader.java
+++ b/src/java/com/twitter/elephantbird/pig/load/LzoThriftB64LinePigLoader.java
@@ -2,6 +2,7 @@ package com.twitter.elephantbird.pig.load;
 
 import java.io.IOException;
 
+import org.apache.hadoop.io.LongWritable;
 import org.apache.hadoop.mapreduce.InputFormat;
 import org.apache.hadoop.mapreduce.Job;
 import org.apache.pig.Expression;
@@ -17,6 +18,7 @@ import com.twitter.elephantbird.mapreduce.input.LzoThriftB64LineInputFormat;
 import com.twitter.elephantbird.mapreduce.io.ThriftWritable;
 import com.twitter.elephantbird.pig.util.PigUtil;
 import com.twitter.elephantbird.pig.util.ThriftToPig;
+
 import com.twitter.elephantbird.util.TypeRef;
 
 public class LzoThriftB64LinePigLoader<M extends TBase<?, ?>> extends LzoBaseLoadFunc implements LoadMetadata {
@@ -28,8 +30,6 @@ public class LzoThriftB64LinePigLoader<M extends TBase<?, ?>> extends LzoBaseLoa
   public LzoThriftB64LinePigLoader(String thriftClassName) {
     typeRef_ = PigUtil.getThriftTypeRef(thriftClassName);
     thriftToPig_ =  ThriftToPig.newInstance(typeRef_);
-
-    setLoaderSpec(getClass(), new String[]{thriftClassName});
   }
 
   /**
@@ -61,21 +61,8 @@ public class LzoThriftB64LinePigLoader<M extends TBase<?, ?>> extends LzoBaseLoa
   }
 
   @Override
-  public InputFormat getInputFormat() throws IOException {
-      try {
-        return LzoThriftB64LineInputFormat.getInputFormatClass(typeRef_.getRawClass(), jobConf).newInstance();
-      } catch (InstantiationException e) {
-        throw new IOException(e);
-      } catch (IllegalAccessException e) {
-        throw new IOException(e);
-      }
-  }
-
-  @Override
-  public void setLocation(String location, Job job) throws IOException {
-    super.setLocation(location, job);
-    // getInputFormat needs a chance to modify the jobConf
-    getInputFormat();
+  public InputFormat<LongWritable, ThriftWritable<M>> getInputFormat() throws IOException {
+    return new LzoThriftB64LineInputFormat<M>(typeRef_);
   }
 
   /**

--- a/src/java/com/twitter/elephantbird/pig/load/LzoThriftBlockPigLoader.java
+++ b/src/java/com/twitter/elephantbird/pig/load/LzoThriftBlockPigLoader.java
@@ -2,6 +2,7 @@ package com.twitter.elephantbird.pig.load;
 
 import java.io.IOException;
 
+import org.apache.hadoop.io.LongWritable;
 import org.apache.hadoop.mapreduce.InputFormat;
 import org.apache.hadoop.mapreduce.Job;
 import org.apache.pig.Expression;
@@ -9,7 +10,6 @@ import org.apache.pig.LoadMetadata;
 import org.apache.pig.ResourceSchema;
 import org.apache.pig.ResourceStatistics;
 import org.apache.pig.data.Tuple;
-import org.apache.pig.impl.util.Pair;
 import org.apache.thrift.TBase;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -30,8 +30,6 @@ public class LzoThriftBlockPigLoader<M extends TBase<?, ?>> extends LzoBaseLoadF
   public LzoThriftBlockPigLoader(String thriftClassName) {
     typeRef_ = PigUtil.getThriftTypeRef(thriftClassName);
     thriftToPig_ =  ThriftToPig.newInstance(typeRef_);
-
-    setLoaderSpec(getClass(), new String[]{thriftClassName});
   }
 
   /**
@@ -62,16 +60,9 @@ public class LzoThriftBlockPigLoader<M extends TBase<?, ?>> extends LzoBaseLoadF
     return new ResourceSchema(ThriftToPig.toSchema(typeRef_.getRawClass()));
   }
 
-  @SuppressWarnings("rawtypes")
   @Override
-  public InputFormat getInputFormat() throws IOException {
-      try {
-        return LzoThriftBlockInputFormat.getInputFormatClass(typeRef_.getRawClass(), jobConf).newInstance();
-      } catch (InstantiationException e) {
-        throw new IOException(e);
-      } catch (IllegalAccessException e) {
-        throw new IOException(e);
-      }
+  public InputFormat<LongWritable, ThriftWritable<M>> getInputFormat() throws IOException {
+    return new LzoThriftBlockInputFormat<M>(typeRef_);
   }
 
   /**

--- a/src/java/com/twitter/elephantbird/pig/load/LzoTokenizedLoader.java
+++ b/src/java/com/twitter/elephantbird/pig/load/LzoTokenizedLoader.java
@@ -44,7 +44,6 @@ public class LzoTokenizedLoader extends LzoBaseLoadFunc {
       throw new IllegalArgumentException();
     }
     // Store the constructor args so that individual slicers can recreate them.
-    setLoaderSpec(getClass(), new String[] { delimiter });
     fieldDel_ = PigTokenHelper.evaluateDelimiter(delimiter);
   }
 

--- a/src/java/com/twitter/elephantbird/pig/store/LzoProtobufB64LinePigStorage.java
+++ b/src/java/com/twitter/elephantbird/pig/store/LzoProtobufB64LinePigStorage.java
@@ -31,6 +31,8 @@ public class LzoProtobufB64LinePigStorage<M extends Message> extends LzoBaseStor
   private TypeRef<M> typeRef_;
   private ProtobufWritable<M> writable;
 
+  // TODO: should remove the default constructor. mostly not used anymore.
+  // Same for other Protobuf loaders, input and output formats.
   public LzoProtobufB64LinePigStorage() {}
 
   public LzoProtobufB64LinePigStorage(String protoClassName) {
@@ -59,14 +61,13 @@ public class LzoProtobufB64LinePigStorage<M extends Message> extends LzoBaseStor
     }
   }
 
-  @SuppressWarnings("rawtypes")
   @Override
-  public OutputFormat getOutputFormat() throws IOException {
+  public OutputFormat<NullWritable, ProtobufWritable<M>> getOutputFormat() throws IOException {
     if (typeRef_ == null) {
       LOG.error("Protobuf class must be specified before an OutputFormat can be created. Do not use the no-argument constructor.");
       throw new IllegalArgumentException("Protobuf class must be specified before an OutputFormat can be created. Do not use the no-argument constructor.");
     }
-    return new LzoProtobufB64LineOutputFormat<M>();
+    return new LzoProtobufB64LineOutputFormat<M>(typeRef_);
   }
 
   @Override

--- a/src/java/com/twitter/elephantbird/pig/store/LzoProtobufBlockPigStorage.java
+++ b/src/java/com/twitter/elephantbird/pig/store/LzoProtobufBlockPigStorage.java
@@ -60,14 +60,13 @@ public class LzoProtobufBlockPigStorage<M extends Message> extends LzoBaseStoreF
     }
   }
 
-  @SuppressWarnings("rawtypes")
   @Override
-  public OutputFormat getOutputFormat() throws IOException {
+  public OutputFormat<NullWritable, ProtobufWritable<M>> getOutputFormat() throws IOException {
     if (typeRef_ == null) {
       LOG.error("Protobuf class must be specified before an OutputFormat can be created. Do not use the no-argument constructor.");
       throw new IllegalArgumentException("Protobuf class must be specified before an OutputFormat can be created. Do not use the no-argument constructor.");
     }
-    return LzoProtobufBlockOutputFormat.newInstance(typeRef_);
+    return new LzoProtobufBlockOutputFormat<M>(typeRef_);
   }
 
 }

--- a/src/java/com/twitter/elephantbird/pig/store/LzoThriftB64LinePigStorage.java
+++ b/src/java/com/twitter/elephantbird/pig/store/LzoThriftB64LinePigStorage.java
@@ -50,17 +50,7 @@ public class LzoThriftB64LinePigStorage<T extends TBase<?, ?>> extends LzoBaseSt
   }
 
   @Override
-  public OutputFormat getOutputFormat() throws IOException {
-    if (typeRef == null) {
-      LOG.error("Thrift class must be specified before an OutputFormat can be created. Do not use the no-argument constructor.");
-      throw new IllegalArgumentException("Thrift class must be specified before an OutputFormat can be created. Do not use the no-argument constructor.");
-    }
-    return new LzoThriftB64LineOutputFormat<T>();
-  }
-
-  @Override
-  public void setStoreLocation(String location, Job job) throws IOException {
-    super.setStoreLocation(location, job);
-    LzoThriftB64LineOutputFormat.getOutputFormatClass(typeRef.getRawClass(), job.getConfiguration());
+  public OutputFormat<NullWritable, ThriftWritable<T>> getOutputFormat() throws IOException {
+    return new LzoThriftB64LineOutputFormat<T>(typeRef);
   }
 }

--- a/src/java/com/twitter/elephantbird/pig/store/LzoThriftBlockPigStorage.java
+++ b/src/java/com/twitter/elephantbird/pig/store/LzoThriftBlockPigStorage.java
@@ -51,16 +51,6 @@ public class LzoThriftBlockPigStorage<T extends TBase<?, ?>> extends LzoBaseStor
 
   @Override
   public OutputFormat getOutputFormat() throws IOException {
-    if (typeRef == null) {
-      LOG.error("Thrift class must be specified before an OutputFormat can be created. Do not use the no-argument constructor.");
-      throw new IllegalArgumentException("Thrift class must be specified before an OutputFormat can be created. Do not use the no-argument constructor.");
-    }
-    return new LzoThriftBlockOutputFormat<T>();
-  }
-
-  @Override
-  public void setStoreLocation(String location, Job job) throws IOException {
-    super.setStoreLocation(location, job);
-    LzoThriftBlockOutputFormat.getOutputFormatClass(typeRef.getRawClass(), job.getConfiguration());
+    return new LzoThriftBlockOutputFormat<T>(typeRef);
   }
 }


### PR DESCRIPTION
We don't need to use conf to figure out typeRef since PIG instantiates these classes with correct args. In fact using conf breaks when a PIG script has multiple loaders with different Thrift/Protobuf classes.
