### PR TITLE
Fix is splittable

### DIFF
--- a/src/java/com/twitter/elephantbird/mapreduce/input/LzoInputFormat.java
+++ b/src/java/com/twitter/elephantbird/mapreduce/input/LzoInputFormat.java
@@ -101,8 +101,8 @@ public abstract class LzoInputFormat<K, V> extends FileInputFormat<K, V> {
     try {
       FileSystem fs = filename.getFileSystem( context.getConfiguration() );
       return fs.exists( filename.suffix( LzoIndex.LZO_INDEX_SUFFIX ) );
-    } catch (IOException e) {
-      return false;
+    } catch (IOException e) { // not expected
+      throw new RuntimeException(e);
     }
   }
 
@@ -154,7 +154,7 @@ public abstract class LzoInputFormat<K, V> extends FileInputFormat<K, V> {
       }
       // else ignore the data?
       // should handle splitting the entire file here so that
-      // such errors cab be handled better.
+      // such errors can be handled better.
     }
 
     return result;


### PR DESCRIPTION
Recently we changed LzoIndexFormat.isSplittable() to alway return true. We were in a hurry didin't realize that can mess up large lzo files that don't have index file. 

isSplittable is used by FileInpufFormat().

Also cached the index from prev split in order to avoid reading the same index file for a file with multiple blocks.
