### PR TITLE
Updated compatibility notes in Readme file

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -26,10 +26,10 @@ NOTE: This is an experimental branch for working with Pig 0.8. It may not work. 
 
 ### Version compatibility ###
 
-1. Protocol Buffers 2.3
+1. Protocol Buffers 2.3 (not compatible with 2.4)
 2. Pig 0.8 (not compatible with 0.7 and below)
 4. Hive 0.7 (with HIVE-1616)
-5. Thrift 0.5
+5. Thrift 0.6
 
 
 #### Building Without Protocol Buffers ####


### PR DESCRIPTION
Added a compatibility note to Readme.md vis-à-vis elephant-bird's lack of support for Protobuf 2.4, and changed the Thrift compatibility note to reflect build.xml's actual behavior (i.e., requiring Thrift 0.6, not 0.5).
