### PR TITLE
Handle corrupt records in LzoRecordReaders

### DIFF
--- a/src/java/com/twitter/elephantbird/mapreduce/input/LzoProtobufB64LineInputFormat.java
+++ b/src/java/com/twitter/elephantbird/mapreduce/input/LzoProtobufB64LineInputFormat.java
@@ -20,6 +20,10 @@ import org.apache.hadoop.mapreduce.TaskAttemptContext;
  *
  * Do not use LzoProtobufB64LineInputFormat.class directly for setting
  * InputFormat class for a job. Use getInputFormatClass() or newInstance(typeRef) instead.
+ *
+ * <p>
+ * A small fraction of bad records are tolerated. See {@link LzoRecordReader}
+ * for more information on error handling.
  */
 
 public class LzoProtobufB64LineInputFormat<M extends Message> extends LzoInputFormat<LongWritable, ProtobufWritable<M>> {

--- a/src/java/com/twitter/elephantbird/mapreduce/input/LzoProtobufBlockInputFormat.java
+++ b/src/java/com/twitter/elephantbird/mapreduce/input/LzoProtobufBlockInputFormat.java
@@ -18,7 +18,11 @@ import org.apache.hadoop.mapreduce.TaskAttemptContext;
  * <br> <br>
  *
  * Do not use LzoProtobufBlockInputFormat.class directly for setting
- * InputFormat class for a job. Use getInputFormatClass() instead.
+ * InputFormat class for a job. Use getInputFormatClass() instead.<p>
+ *
+ * <p>
+ * A small fraction of bad records are tolerated. See {@link LzoRecordReader}
+ * for more information on error handling.
  */
 
 public class LzoProtobufBlockInputFormat<M extends Message> extends LzoInputFormat<LongWritable, ProtobufWritable<M>> {

--- a/src/java/com/twitter/elephantbird/mapreduce/input/LzoRecordReader.java
+++ b/src/java/com/twitter/elephantbird/mapreduce/input/LzoRecordReader.java
@@ -17,11 +17,21 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * An abstract base class that handles setting up all LZO-based RecordReaders.
+ * An abstract base class that handles setting up all LZO-based RecordReaders. <p>
+ *
+ * <b>Error handling:</b><br>
+ * A small fraction of bad records are tolerated. When deserialization
+ * of a record results in an exception or a null object, an a warning
+ * is logged. If the rate of errors crosses a threshold
+ * (default is 0.0001 or 0.01%) a RuntimeException is thrown.
+ * The threshold can be set with configuration variable
+ * <code>elephantbird.mapred.input.bad.record.threshold</code>.
+ * A value of 0 disables error handling. <p>
  */
 public abstract class LzoRecordReader<K, V> extends RecordReader<K, V> {
   private static final Logger LOG = LoggerFactory.getLogger(LzoRecordReader.class);
 
+  public static final String BAD_RECORD_THRESHOLD_CONF_KEY = "elephantbird.mapred.input.bad.record.threshold";
   protected long start_;
   protected long pos_;
   protected long end_;
@@ -104,7 +114,7 @@ public abstract class LzoRecordReader<K, V> extends RecordReader<K, V> {
 
     InputErrorTracker(Configuration conf) {
       //default threshold : 0.01%
-      errorThreshold = conf.getFloat("elephantbird.mapred.input.errors.threshold", 0.0001f);
+      errorThreshold = conf.getFloat(BAD_RECORD_THRESHOLD_CONF_KEY, 0.0001f);
       numRecords = 0;
       numErrors = 0;
     }
@@ -128,7 +138,8 @@ public abstract class LzoRecordReader<K, V> extends RecordReader<K, V> {
         throw new RuntimeException("error while reading input records", cause);
       }
 
-      LOG.warn("Error while reading an input record (" + numErrors + " so far ): ", cause);
+      LOG.warn("Error while reading an input record ("
+          + numErrors + " out of " + numRecords + " so far ): ", cause);
 
       double errRate = numErrors/(double)numErrors;
 

--- a/src/java/com/twitter/elephantbird/mapreduce/input/LzoThriftB64LineInputFormat.java
+++ b/src/java/com/twitter/elephantbird/mapreduce/input/LzoThriftB64LineInputFormat.java
@@ -19,7 +19,11 @@ import com.twitter.elephantbird.util.TypeRef;
  * Returns <position, thriftObject> pairs. <br><br>
  *
  * Do not use LzoThriftB64LineInputFormat.class directly for setting
- * InputFormat class for a job. Use getInputFormatClass() instead.
+ * InputFormat class for a job. Use getInputFormatClass() instead.<p>
+ *
+ * <p>
+ * A small fraction of bad records are tolerated. See {@link LzoRecordReader}
+ * for more information on error handling.
  */
 public class LzoThriftB64LineInputFormat<M extends TBase<?, ?>>
                 extends LzoInputFormat<LongWritable, ThriftWritable<M>> {

--- a/src/java/com/twitter/elephantbird/mapreduce/input/LzoThriftB64LineRecordReader.java
+++ b/src/java/com/twitter/elephantbird/mapreduce/input/LzoThriftB64LineRecordReader.java
@@ -13,7 +13,7 @@ public class  LzoThriftB64LineRecordReader<M extends TBase<?, ?>> extends LzoBin
 
   public LzoThriftB64LineRecordReader(TypeRef<M> typeRef) {
     super(typeRef, new ThriftWritable<M>(typeRef), new ThriftConverter<M>(typeRef));
-    LOG.info("LzoTProtoB64LineRecordReader, type is " + typeRef.getRawClass());
+    LOG.info("record type is " + typeRef.getRawClass());
   }
 }
 

--- a/src/java/com/twitter/elephantbird/mapreduce/input/LzoThriftBlockInputFormat.java
+++ b/src/java/com/twitter/elephantbird/mapreduce/input/LzoThriftBlockInputFormat.java
@@ -19,6 +19,10 @@ import org.apache.thrift.TBase;
  *
  * Do not use LzoThriftBlockInputFormat.class directly for setting
  * InputFormat class for a job. Use getInputFormatClass() instead.
+ *
+ * <p>
+ * A small fraction of bad records are tolerated. See {@link LzoRecordReader}
+ * for more information on error handling.
  */
 public class LzoThriftBlockInputFormat<M extends TBase<?, ?>>
                 extends LzoInputFormat<LongWritable, ThriftWritable<M>> {

--- a/src/java/com/twitter/elephantbird/pig/load/LzoProtobufB64LinePigLoader.java
+++ b/src/java/com/twitter/elephantbird/pig/load/LzoProtobufB64LinePigLoader.java
@@ -12,6 +12,7 @@ import org.slf4j.LoggerFactory;
 
 import com.google.protobuf.Message;
 import com.twitter.elephantbird.mapreduce.input.LzoProtobufB64LineInputFormat;
+import com.twitter.elephantbird.mapreduce.input.LzoRecordReader;
 import com.twitter.elephantbird.mapreduce.io.ProtobufWritable;
 import com.twitter.elephantbird.pig.util.PigUtil;
 import com.twitter.elephantbird.pig.util.ProtobufToPig;
@@ -56,6 +57,9 @@ public class LzoProtobufB64LinePigLoader<M extends Message> extends LzoBaseLoadF
 
   /**
    * Return every non-null line as a single-element tuple to Pig.
+   * <p>
+   * A small fraction of bad records in input are tolerated.
+   * See  {@link LzoRecordReader} for more information on error handling.
    */
   @Override
   public Tuple getNext() throws IOException {

--- a/src/java/com/twitter/elephantbird/pig/load/LzoProtobufBlockPigLoader.java
+++ b/src/java/com/twitter/elephantbird/pig/load/LzoProtobufBlockPigLoader.java
@@ -10,6 +10,7 @@ import org.apache.pig.data.Tuple;
 
 import com.google.protobuf.Message;
 import com.twitter.elephantbird.mapreduce.input.LzoProtobufBlockInputFormat;
+import com.twitter.elephantbird.mapreduce.input.LzoRecordReader;
 import com.twitter.elephantbird.mapreduce.io.ProtobufWritable;
 import com.twitter.elephantbird.pig.util.PigUtil;
 import com.twitter.elephantbird.pig.util.ProtobufToPig;
@@ -51,6 +52,12 @@ public class LzoProtobufBlockPigLoader<M extends Message> extends LzoBaseLoadFun
     typeRef_ = typeRef;
   }
 
+  /**
+   * Return next Protobuf Tuple from input.
+   * <p>
+   * A small fraction of bad records in input are tolerated.
+   * See  {@link LzoRecordReader} for more information on error handling.
+   */
   public Tuple getNext() throws IOException {
     M value = getNextBinaryValue(typeRef_);
 

--- a/src/java/com/twitter/elephantbird/pig/load/LzoThriftB64LinePigLoader.java
+++ b/src/java/com/twitter/elephantbird/pig/load/LzoThriftB64LinePigLoader.java
@@ -10,6 +10,7 @@ import org.apache.pig.ResourceSchema;
 import org.apache.pig.data.Tuple;
 import org.apache.thrift.TBase;
 
+import com.twitter.elephantbird.mapreduce.input.LzoRecordReader;
 import com.twitter.elephantbird.mapreduce.input.LzoThriftB64LineInputFormat;
 import com.twitter.elephantbird.mapreduce.io.ThriftWritable;
 import com.twitter.elephantbird.pig.util.PigUtil;
@@ -29,6 +30,9 @@ public class LzoThriftB64LinePigLoader<M extends TBase<?, ?>> extends LzoBaseLoa
 
   /**
    * Return every non-null line as a single-element tuple to Pig.
+   *<p>
+   * A small fraction of bad records are tolerated. See {@link LzoRecordReader}
+   * for more information on error handling.
    */
   @Override
   public Tuple getNext() throws IOException {

--- a/src/java/com/twitter/elephantbird/pig/load/LzoThriftBlockPigLoader.java
+++ b/src/java/com/twitter/elephantbird/pig/load/LzoThriftBlockPigLoader.java
@@ -9,6 +9,7 @@ import org.apache.pig.ResourceSchema;
 import org.apache.pig.data.Tuple;
 import org.apache.thrift.TBase;
 
+import com.twitter.elephantbird.mapreduce.input.LzoRecordReader;
 import com.twitter.elephantbird.mapreduce.input.LzoThriftBlockInputFormat;
 import com.twitter.elephantbird.mapreduce.io.ThriftWritable;
 import com.twitter.elephantbird.pig.util.PigUtil;
@@ -26,6 +27,14 @@ public class LzoThriftBlockPigLoader<M extends TBase<?, ?>> extends LzoBaseLoadF
     thriftToPig_ =  ThriftToPig.newInstance(typeRef_);
   }
 
+  /**
+   * Returns next Tuple for the Thrift object read from the input.
+   * <p>
+   * A small fraction of bad records are tolerated. See {@link LzoRecordReader}
+   * for more information on error handling.
+   *
+   * @see org.apache.pig.LoadFunc#getNext()
+   */
   @Override
   public Tuple getNext() throws IOException {
     M value = getNextBinaryValue(typeRef_);


### PR DESCRIPTION
This patch allows a small fraction of input recors to be corrupt. 
One recent example :  one of the base64 encoded files had one line with two binary bytes (not sure how they got there), and it stalled the processing. 

This patch prints a warning and if the error rate is crosses 0.01%, throws an exception.
