### PR TITLE
Fix empty line check

### DIFF
--- a/src/java/com/twitter/elephantbird/mapreduce/input/LzoBinaryB64LineRecordReader.java
+++ b/src/java/com/twitter/elephantbird/mapreduce/input/LzoBinaryB64LineRecordReader.java
@@ -113,7 +113,7 @@ public class  LzoBinaryB64LineRecordReader<M, W extends BinaryWritable<M>> exten
       }
       linesReadCounter.increment(1);
       pos_ = getLzoFilePos();
-      if (line_.equals("\n")) {
+      if (line_.getLength() == 0 || line_.charAt(0) == '\n') {
         emptyLinesCounter.increment(1);
         continue;
       }


### PR DESCRIPTION
We always intended to skip empty lines. But the check was incorrect since 'line_' is not String but a Text().
The check always returned false.

We used to silently ignore deserialization errors and this didn't show up earlier.
