### PR TITLE
Pig 9 port

### DIFF
--- a/src/java/com/twitter/elephantbird/pig/util/PigUtil.java
+++ b/src/java/com/twitter/elephantbird/pig/util/PigUtil.java
@@ -23,6 +23,21 @@ public class PigUtil {
   }
 
   /**
+   * Temporary hack to check if PIG version is 0.9.0 or newer
+   */
+  public static final boolean Pig9orNewer;
+  static {
+    boolean methodFound = false;
+    try {
+      // check for a new method in a class common to both Pig 0.8 and 0.9
+      Class<?> cls = Class.forName("org.apache.pig.EvalFunc");
+      methodFound = cls.getMethod("getCacheFiles") != null;
+    } catch (Exception e) {
+    }
+    Pig9orNewer = methodFound;
+  }
+
+  /**
    * Returns class using Pig's class loader.
    * If that fails tries {@link Protobufs#getProtobufClass(String)} to
    * resolve the class

--- a/src/java/com/twitter/elephantbird/pig/util/ProtobufToPig.java
+++ b/src/java/com/twitter/elephantbird/pig/util/ProtobufToPig.java
@@ -6,7 +6,6 @@ import java.util.Map;
 import com.google.common.base.Joiner;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
-import com.google.protobuf.DescriptorProtos.DescriptorProto;
 import com.google.protobuf.Descriptors.Descriptor;
 import com.google.protobuf.Descriptors.EnumValueDescriptor;
 import com.google.protobuf.Descriptors.FieldDescriptor;

--- a/src/java/com/twitter/elephantbird/pig/util/ThriftToPig.java
+++ b/src/java/com/twitter/elephantbird/pig/util/ThriftToPig.java
@@ -276,6 +276,9 @@ public class ThriftToPig<M extends TBase<?, ?>> {
         break;
       default:
         fieldSchema = new FieldSchema(fieldName, null, getPigDataType(field));
+        if ( PigUtil.Pig9orNewer ) { // bag needs tuples (PIG 0.8 implicitly added this wrapper)
+          fieldSchema = new FieldSchema( "t", new Schema(fieldSchema),  DataType.TUPLE );
+        }
     }
 
     Schema schema = new Schema();


### PR DESCRIPTION
The patch detects Pig 0.9 or newer version so  that simple types in PIG bags.

PIG 0.8 added an implicit wrapper (and removed this wrapper while reading).
PIG 0.9 is more consistent and expects the Loader to export proper schema.

ProtobufToPig was not affected by this patch since it always added this wrapper (but would not work with PIG 0.8 and older).
