### PR TITLE
Adds LongWritableConverter and...

### DIFF
--- a/src/java/com/twitter/elephantbird/pig/load/SequenceFileLoader.java
+++ b/src/java/com/twitter/elephantbird/pig/load/SequenceFileLoader.java
@@ -38,6 +38,7 @@ import org.apache.pig.ResourceStatistics;
 import org.apache.pig.backend.executionengine.ExecException;
 import org.apache.pig.backend.hadoop.executionengine.mapReduceLayer.PigSplit;
 import org.apache.pig.data.DataByteArray;
+import org.apache.pig.data.DataType;
 import org.apache.pig.data.Tuple;
 import org.apache.pig.data.TupleFactory;
 import org.apache.pig.impl.logicalLayer.FrontendException;
@@ -293,8 +294,16 @@ public class SequenceFileLoader<K extends Writable, V extends Writable> extends 
   public ResourceSchema getSchema(String location, Job job) throws IOException {
     ResourceSchema resourceSchema = new ResourceSchema();
     ResourceFieldSchema keySchema = keyConverter.getLoadSchema();
+    if (keySchema == null) {
+      keySchema = new ResourceFieldSchema();
+      keySchema.setType(DataType.BYTEARRAY);
+    }
     keySchema.setName("key");
     ResourceFieldSchema valueSchema = valueConverter.getLoadSchema();
+    if (valueSchema == null) {
+      valueSchema = new ResourceFieldSchema();
+      valueSchema.setType(DataType.BYTEARRAY);
+    }
     valueSchema.setName("value");
     resourceSchema.setFields(new ResourceFieldSchema[] { keySchema, valueSchema });
     return resourceSchema;

--- a/src/java/com/twitter/elephantbird/pig/util/AbstractWritableConverter.java
+++ b/src/java/com/twitter/elephantbird/pig/util/AbstractWritableConverter.java
@@ -35,9 +35,7 @@ public abstract class AbstractWritableConverter<W extends Writable> extends Writ
    */
   @Override
   public ResourceFieldSchema getLoadSchema() throws IOException {
-    ResourceFieldSchema schema = new ResourceFieldSchema();
-    schema.setType(DataType.BYTEARRAY);
-    return schema;
+    return null;
   }
 
   /**

--- a/src/java/com/twitter/elephantbird/pig/util/IntWritableConverter.java
+++ b/src/java/com/twitter/elephantbird/pig/util/IntWritableConverter.java
@@ -10,7 +10,7 @@ import org.apache.pig.data.DataByteArray;
 import org.apache.pig.data.DataType;
 
 /**
- * Supports conversion between Pig int type (Integer) and {@link IntWritable}.
+ * Supports conversion between Pig types and {@link IntWritable}.
  *
  * @author Andy Schlaikjer
  */
@@ -72,32 +72,35 @@ public class IntWritableConverter extends AbstractWritableConverter<IntWritable>
 
   @Override
   protected IntWritable toWritable(String value, boolean newInstance) throws IOException {
+    Preconditions.checkNotNull(value);
     return toWritable(Integer.parseInt(value), newInstance);
   }
 
   @Override
   protected IntWritable toWritable(Integer value, boolean newInstance) throws IOException {
     Preconditions.checkNotNull(value);
-    if (newInstance)
-      return new IntWritable(value);
-    if (writable == null)
+    if (writable == null) {
       writable = new IntWritable();
+    }
     writable.set(value);
     return writable;
   }
 
   @Override
   protected IntWritable toWritable(Long value, boolean newInstance) throws IOException {
+    Preconditions.checkNotNull(value);
     return toWritable(value.intValue(), newInstance);
   }
 
   @Override
   protected IntWritable toWritable(Float value, boolean newInstance) throws IOException {
+    Preconditions.checkNotNull(value);
     return toWritable(value.intValue(), newInstance);
   }
 
   @Override
   protected IntWritable toWritable(Double value, boolean newInstance) throws IOException {
+    Preconditions.checkNotNull(value);
     return toWritable(value.intValue(), newInstance);
   }
 }

--- a/src/java/com/twitter/elephantbird/pig/util/LongWritableConverter.java
+++ b/src/java/com/twitter/elephantbird/pig/util/LongWritableConverter.java
@@ -1,0 +1,106 @@
+package com.twitter.elephantbird.pig.util;
+
+import java.io.IOException;
+
+import com.google.common.base.Preconditions;
+
+import org.apache.hadoop.io.LongWritable;
+import org.apache.pig.ResourceSchema.ResourceFieldSchema;
+import org.apache.pig.data.DataByteArray;
+import org.apache.pig.data.DataType;
+
+/**
+ * Supports conversion between Pig types and {@link LongWritable}.
+ *
+ * @author Andy Schlaikjer
+ */
+public class LongWritableConverter extends AbstractWritableConverter<LongWritable> {
+  public LongWritableConverter() {
+    super();
+    this.writable = new LongWritable();
+  }
+
+  @Override
+  public ResourceFieldSchema getLoadSchema() throws IOException {
+    ResourceFieldSchema schema = new ResourceFieldSchema();
+    schema.setType(DataType.LONG);
+    return schema;
+  }
+
+  @Override
+  public Object bytesToObject(DataByteArray dataByteArray) throws IOException {
+    return bytesToLong(dataByteArray.get());
+  }
+
+  @Override
+  protected String toCharArray(LongWritable writable) throws IOException {
+    return String.valueOf(writable.get());
+  }
+
+  @Override
+  protected Integer toInteger(LongWritable writable) throws IOException {
+    return (int) writable.get();
+  }
+
+  @Override
+  protected Long toLong(LongWritable writable) throws IOException {
+    return writable.get();
+  }
+
+  @Override
+  protected Float toFloat(LongWritable writable) throws IOException {
+    return (float) writable.get();
+  }
+
+  @Override
+  protected Double toDouble(LongWritable writable) throws IOException {
+    return (double) writable.get();
+  }
+
+  @Override
+  public void checkStoreSchema(ResourceFieldSchema schema) throws IOException {
+    switch (schema.getType()) {
+      case DataType.CHARARRAY:
+      case DataType.INTEGER:
+      case DataType.LONG:
+      case DataType.FLOAT:
+      case DataType.DOUBLE:
+        return;
+    }
+    throw new IOException("Pig type '" + DataType.findTypeName(schema.getType()) + "' unsupported");
+  }
+
+  @Override
+  protected LongWritable toWritable(String value, boolean newInstance) throws IOException {
+    Preconditions.checkNotNull(value);
+    return toWritable(Long.parseLong(value), newInstance);
+  }
+
+  @Override
+  protected LongWritable toWritable(Integer value, boolean newInstance) throws IOException {
+    Preconditions.checkNotNull(value);
+    return toWritable(value.longValue(), newInstance);
+  }
+
+  @Override
+  protected LongWritable toWritable(Long value, boolean newInstance) throws IOException {
+    Preconditions.checkNotNull(value);
+    if (newInstance) {
+      writable = new LongWritable();
+    }
+    writable.set(value);
+    return writable;
+  }
+
+  @Override
+  protected LongWritable toWritable(Float value, boolean newInstance) throws IOException {
+    Preconditions.checkNotNull(value);
+    return toWritable(value.longValue(), newInstance);
+  }
+
+  @Override
+  protected LongWritable toWritable(Double value, boolean newInstance) throws IOException {
+    Preconditions.checkNotNull(value);
+    return toWritable(value.longValue(), newInstance);
+  }
+}

--- a/src/test/com/twitter/elephantbird/pig/util/AbstractTestWritableConverter.java
+++ b/src/test/com/twitter/elephantbird/pig/util/AbstractTestWritableConverter.java
@@ -47,7 +47,7 @@ public abstract class AbstractTestWritableConverter<W extends Writable, C extend
   private final Class<C> writableConverterClass;
   private final String writableConverterArguments;
   private final W[] data;
-  private final String[][] expected;
+  private final String[] expected;
   private final String valueSchema;
   protected PigServer pigServer;
   protected String tempFilename;
@@ -60,11 +60,7 @@ public abstract class AbstractTestWritableConverter<W extends Writable, C extend
     this.writableConverterArguments =
         writableConverterArguments == null ? "" : writableConverterArguments;
     this.data = data;
-    this.expected = new String[expected.length][2];
-    for (int i = 0; i < expected.length; ++i) {
-      this.expected[i][0] = Integer.toString(i);
-      this.expected[i][1] = expected[i];
-    }
+    this.expected = expected;
     this.valueSchema = valueSchema;
   }
 
@@ -154,16 +150,13 @@ public abstract class AbstractTestWritableConverter<W extends Writable, C extend
 
   protected void validate(final Iterator<Tuple> it) throws ExecException {
     int tupleCount = 0;
-    while (it.hasNext()) {
+    for (; it.hasNext(); ++tupleCount) {
       final Tuple tuple = it.next();
       Assert.assertNotNull(tuple);
       Assert.assertEquals(2, tuple.size());
-      for (int i = 0; i < 2; ++i) {
-        final Object entry = tuple.get(i);
-        Assert.assertNotNull(entry);
-        Assert.assertEquals(expected[tupleCount][i], entry.toString());
-      }
-      tupleCount++;
+      Object value = tuple.get(1);
+      Assert.assertNotNull(value);
+      Assert.assertEquals(expected[tupleCount], value.toString());
     }
     Assert.assertEquals(data.length, tupleCount);
   }

--- a/src/test/com/twitter/elephantbird/pig/util/IntegrationTestIntWritableConverter.java
+++ b/src/test/com/twitter/elephantbird/pig/util/IntegrationTestIntWritableConverter.java
@@ -1,0 +1,17 @@
+package com.twitter.elephantbird.pig.util;
+
+import org.apache.hadoop.io.IntWritable;
+
+/**
+ * @author Andy Schlaikjer
+ */
+public class IntegrationTestIntWritableConverter extends
+    AbstractTestWritableConverter<IntWritable, IntWritableConverter> {
+  private static final IntWritable[] DATA = { new IntWritable(1), new IntWritable(2),
+          new IntWritable(3) };
+  private static final String[] EXPECTED = { "1", "2", "3" };
+
+  public IntegrationTestIntWritableConverter() {
+    super(IntWritable.class, IntWritableConverter.class, "", DATA, EXPECTED, "int");
+  }
+}

--- a/src/test/com/twitter/elephantbird/pig/util/IntegrationTestLongWritableConverter.java
+++ b/src/test/com/twitter/elephantbird/pig/util/IntegrationTestLongWritableConverter.java
@@ -1,0 +1,17 @@
+package com.twitter.elephantbird.pig.util;
+
+import org.apache.hadoop.io.LongWritable;
+
+/**
+ * @author Andy Schlaikjer
+ */
+public class IntegrationTestLongWritableConverter extends
+    AbstractTestWritableConverter<LongWritable, LongWritableConverter> {
+  private static final LongWritable[] DATA = { new LongWritable(1), new LongWritable(2),
+          new LongWritable(4294967296l) };
+  private static final String[] EXPECTED = { "1", "2", "4294967296" };
+
+  public IntegrationTestLongWritableConverter() {
+    super(LongWritable.class, LongWritableConverter.class, "", DATA, EXPECTED, "long");
+  }
+}

--- a/src/test/com/twitter/elephantbird/pig/util/IntegrationTestTextConverter.java
+++ b/src/test/com/twitter/elephantbird/pig/util/IntegrationTestTextConverter.java
@@ -1,0 +1,19 @@
+package com.twitter.elephantbird.pig.util;
+
+import org.apache.hadoop.io.Text;
+
+/**
+ * @author Andy Schlaikjer
+ */
+public class IntegrationTestTextConverter extends
+    AbstractTestWritableConverter<Text, TextConverter> {
+  private static final String V1 = "one, two, buckle my shoe";
+  private static final String V2 = "three, four, knock on my door";
+  private static final String V3 = "five, six, pickup sticks";
+  private static final Text[] DATA = { new Text(V1), new Text(V2), new Text(V3) };
+  private static final String[] EXPECTED = { V1, V2, V3 };
+
+  public IntegrationTestTextConverter() {
+    super(Text.class, TextConverter.class, "", DATA, EXPECTED, "chararray");
+  }
+}


### PR DESCRIPTION
- Fixes SequenceFileLoader.getLoadSchema(...) to prevent NPEs
- Rewrites AbstractWritableConverter.getLoadSchema(...) so impl matches its javadoc and returns null
- Adds preconditions tests to various methods within IntWritableConverter
- Adds IntegrationTest*WritableConverter tests (not regular unit tests as these don't have to be run frequently and take a long time to complete)
