### PR TITLE
Fix for sequencfileloader getwritableconverter

### DIFF
--- a/src/test/com/twitter/elephantbird/pig/util/IntegrationTestTextConverter.java
+++ b/src/test/com/twitter/elephantbird/pig/util/IntegrationTestTextConverter.java
@@ -1,6 +1,11 @@
 package com.twitter.elephantbird.pig.util;
 
+import java.io.IOException;
+
 import org.apache.hadoop.io.Text;
+import org.junit.Test;
+
+import com.twitter.elephantbird.pig.store.SequenceFileStorage;
 
 /**
  * @author Andy Schlaikjer
@@ -15,5 +20,19 @@ public class IntegrationTestTextConverter extends
 
   public IntegrationTestTextConverter() {
     super(Text.class, TextConverter.class, "", DATA, EXPECTED, "chararray");
+  }
+
+  @Test
+  public void testDefaultCtor() throws IOException {
+    pigServer.registerQuery(String.format("A = LOAD 'file:%s' USING %s();", tempFilename,
+        SequenceFileStorage.class.getName()));
+    validate(pigServer.openIterator("A"));
+  }
+
+  @Test
+  public void testDefaultCtor02() throws IOException {
+    pigServer.registerQuery(String.format("A = LOAD 'file:%s' USING %s('', '');", tempFilename,
+        SequenceFileStorage.class.getName()));
+    validate(pigServer.openIterator("A"));
   }
 }


### PR DESCRIPTION
Fixes bug in SequenceFileLoader.getWritableConverter(...) which causes runtime error when using WritableConverter impls which have only default (no-args) ctor.

Apparently the Apache CLI lib used to parse arg strings may leave empty arg
string(s) after parsing. This was causing SequenceFileLoader to look for
WritableConverter ctors with String and String[] args when it should have been
looking for no-args ctor.
