### PR TITLE
WritableLoadCaster compatibility with Pig 0.9

### DIFF
--- a/src/java/com/twitter/elephantbird/pig/util/WritableLoadCaster.java
+++ b/src/java/com/twitter/elephantbird/pig/util/WritableLoadCaster.java
@@ -77,6 +77,10 @@ public abstract class WritableLoadCaster<W extends Writable> implements LoadCast
   public Map<String, Object> bytesToMap(byte[] bytes) throws IOException {
     return toMap(writable = readFields(bytes, writable));
   }
+  
+  public Map<String, Object> bytesToMap(byte[] bytes, ResourceFieldSchema schema) throws IOException {
+    return toMap(writable = readFields(bytes, writable), schema);
+  }
 
   @Override
   public Tuple bytesToTuple(byte[] bytes, ResourceFieldSchema schema) throws IOException {
@@ -109,6 +113,10 @@ public abstract class WritableLoadCaster<W extends Writable> implements LoadCast
   }
 
   protected Map<String, Object> toMap(W writable) throws IOException {
+    throw new UnsupportedOperationException();
+  }
+  
+  protected Map<String, Object> toMap(W writable, ResourceFieldSchema schema) throws IOException {
     throw new UnsupportedOperationException();
   }
 


### PR DESCRIPTION
This is a minor fix. In pig0.9, they changed around the LoadCaster
interface. Since elephantbird implements this, it is causing errors to
be thrown in code that works in pig0.8. This is a minor fix that makes
these errors go away.
