### PR TITLE
Updated ivy.xml to have com.google.protobuf as groupId

### DIFF
--- a/ivy.xml
+++ b/ivy.xml
@@ -10,7 +10,7 @@
       <exclude org="log4j"/>
       <exclude org="org.apache.hadoop"/>
     </dependency>
-    <dependency org="com.google" name="protobuf-java" rev="${protobuf-java.version}"/>
+    <dependency org="com.google.protobuf" name="protobuf-java" rev="${protobuf-java.version}"/>
     <dependency org="com.google.guava" name="guava" rev="${guava.version}"/>
     <dependency org="com.googlecode.json-simple" name="json-simple" rev="${json-simple.version}"/>
     <dependency org="com.hadoop" name="hadoop-lzo" rev="${hadoop-lzo.version}"/>


### PR DESCRIPTION
In the central maven repo the groupId for protobuf is "com.google.protobuf"
  http://repo1.maven.org/maven2/com/google/protobuf/protobuf-java/2.3.0/protobuf-java-2.3.0.pom
This should work, I cannot test fully as protoc not installed on this machine.
