### PR TITLE
Fix the namespace for cascading2 protobuf stuff

### DIFF
--- a/src/java/com/twitter/elephantbird/cascading2/io/protobuf/ProtobufComparator.java
+++ b/src/java/com/twitter/elephantbird/cascading2/io/protobuf/ProtobufComparator.java
@@ -1,4 +1,4 @@
-package com.twitter.cascading2.io.protobuf;
+package com.twitter.elephantbird.cascading2.io.protobuf;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;

--- a/src/java/com/twitter/elephantbird/cascading2/io/protobuf/ProtobufDeserializer.java
+++ b/src/java/com/twitter/elephantbird/cascading2/io/protobuf/ProtobufDeserializer.java
@@ -1,4 +1,4 @@
-package com.twitter.cascading2.io.protobuf;
+package com.twitter.elephantbird.cascading2.io.protobuf;
 
 import java.io.IOException;
 import java.io.InputStream;

--- a/src/java/com/twitter/elephantbird/cascading2/io/protobuf/ProtobufReflectionUtil.java
+++ b/src/java/com/twitter/elephantbird/cascading2/io/protobuf/ProtobufReflectionUtil.java
@@ -1,4 +1,4 @@
-package com.twitter.cascading2.io.protobuf;
+package com.twitter.elephantbird.cascading2.io.protobuf;
 
 import java.io.InputStream;
 import java.lang.reflect.InvocationTargetException;

--- a/src/java/com/twitter/elephantbird/cascading2/io/protobuf/ProtobufSerialization.java
+++ b/src/java/com/twitter/elephantbird/cascading2/io/protobuf/ProtobufSerialization.java
@@ -1,4 +1,4 @@
-package com.twitter.cascading2.io.protobuf;
+package com.twitter.elephantbird.cascading2.io.protobuf;
 
 import java.util.Comparator;
 

--- a/src/java/com/twitter/elephantbird/cascading2/io/protobuf/ProtobufSerializer.java
+++ b/src/java/com/twitter/elephantbird/cascading2/io/protobuf/ProtobufSerializer.java
@@ -1,4 +1,4 @@
-package com.twitter.cascading2.io.protobuf;
+package com.twitter.elephantbird.cascading2.io.protobuf;
 
 import java.io.IOException;
 import java.io.OutputStream;


### PR DESCRIPTION
These namespaces were never updated to elephantbird and we're about to use them internally.
