### PR TITLE
don't force thrift in classpath

### DIFF
--- a/src/java/com/twitter/elephantbird/mapreduce/input/MultiInputFormat.java
+++ b/src/java/com/twitter/elephantbird/mapreduce/input/MultiInputFormat.java
@@ -150,7 +150,7 @@ public class MultiInputFormat<M>
      */
 
     // most of the cost is opening the file and
-    // reading first lzo block (about 256k of compressed data)
+    // reading first lzo block (about 256k of uncompressed data)
 
     CompressionCodec codec = new CompressionCodecFactory(conf).getCodec(file);
     if (codec == null) {


### PR DESCRIPTION
check Thrift class after protobuf so that MultiInputFormat 
does not require thrift on classpath unless needed.

Tested with loading data with ProtobufPigLoader() with out thrift in classpath.
