### PR TITLE
Issue 146: TestInvoker#testSpeed() may fail on slow machines

### DIFF
--- a/src/test/com/twitter/elephantbird/pig/piggybank/TestInvoker.java
+++ b/src/test/com/twitter/elephantbird/pig/piggybank/TestInvoker.java
@@ -156,27 +156,6 @@ public class TestInvoker {
       return bag;
     }
 
-    @Test
-    public void testSpeed() throws IOException, SecurityException, ClassNotFoundException, NoSuchMethodException {
-        EvalFunc<Double> log = new Log();
-        Tuple tup = tf_.newTuple(1);
-        long start = System.currentTimeMillis();
-        for (int i=0; i < 1000000; i++) {
-            tup.set(0, (double) i);
-            log.exec(tup);
-        }
-        long staticSpeed = (System.currentTimeMillis()-start);
-        start = System.currentTimeMillis();
-        log = new InvokeForDouble("java.lang.Math.log", "Double", "static");
-        for (int i=0; i < 1000000; i++) {
-            tup.set(0, (double) i);
-            log.exec(tup);
-        }
-        long dynamicSpeed = System.currentTimeMillis()-start;
-        System.err.println("Dynamic to static ratio: "+((float) dynamicSpeed)/staticSpeed);
-        assertTrue( ((float) dynamicSpeed)/staticSpeed < 5);
-    }
-    
     private class Log extends EvalFunc<Double> {
 
         @Override


### PR DESCRIPTION
This patch removes the testSpeed() method altogether from the code.

Background:
The "problem" with testSpeed() is that its success seems to depend on
the build environment. Even though a relative ratio is used, this alone
apparently does not guarantee that the test completes successfully on
any box that the build is being run on (e.g. it may pass if the build
box is otherwise idle but it may fail if there are other tasks running
in the background). Also, this unit test is not a functional test but a
performance test.

See https://github.com/kevinweil/elephant-bird/issues/146 for more
information.

FYI: I initially wanted to create the pull request to target kevinweil:eb-dev (your dev branch).  But apparently the eb-dev branch is pretty out of date at the moment compared to kevinweil:master, so I decided to target kevinweil:master instead.  Please let me know if that's ok.
