### PR TITLE
Removes requirement that input Vector data match user specified -dense, -sparse options

### DIFF
--- a/src/test/com/twitter/elephantbird/pig/mahout/TestDenseVectorWritableConverter.java
+++ b/src/test/com/twitter/elephantbird/pig/mahout/TestDenseVectorWritableConverter.java
@@ -83,9 +83,9 @@ public class TestDenseVectorWritableConverter extends
     validate(pigServer.openIterator("A"));
   }
 
-  @Test(expected = Exception.class)
-  public void testLoadInvalidSchema() throws IOException {
+  @Test
+  public void testLoadConversionSchema() throws IOException {
     registerReadQuery("-- -sparse", null);
-    validate(pigServer.openIterator("A"));
+    validate(new String[] { "(3,{(0,1.0),(1,2.0),(2,3.0)})" }, pigServer.openIterator("A"));
   }
 }

--- a/src/test/com/twitter/elephantbird/pig/mahout/TestSequentialAccessSparseVectorWritableConverter.java
+++ b/src/test/com/twitter/elephantbird/pig/mahout/TestSequentialAccessSparseVectorWritableConverter.java
@@ -8,7 +8,6 @@ import org.apache.mahout.math.Vector;
 import org.apache.mahout.math.VectorWritable;
 import org.junit.Test;
 
-import com.twitter.elephantbird.pig.mahout.VectorWritableConverter;
 import com.twitter.elephantbird.pig.util.AbstractTestWritableConverter;
 
 /**
@@ -42,14 +41,14 @@ public class TestSequentialAccessSparseVectorWritableConverter extends
     validate(new String[] { "({(0,1.0),(1,2.0),(2,3.0)})" }, pigServer.openIterator("A"));
   }
 
-  @Test(expected = Exception.class)
-  public void testLoadInvalidSchema01() throws IOException {
+  @Test
+  public void testLoadConversionSchema() throws IOException {
     registerReadQuery("-- -dense -cardinality 3", null);
-    validate(pigServer.openIterator("A"));
+    validate(new String[] { "(1.0,2.0,3.0)" }, pigServer.openIterator("A"));
   }
 
   @Test(expected = Exception.class)
-  public void testLoadInvalidSchema02() throws IOException {
+  public void testLoadInvalidSchema() throws IOException {
     registerReadQuery("-- -sparse -cardinality 2", null);
     validate(pigServer.openIterator("A"));
   }


### PR DESCRIPTION
This allows conversion of dense Vector data to sparse Tuple representation on load, quite useful when dealing with dense vectors with cardinality > 1000 and beyond.

It was kinda funny (i.e. awful) when I tried to manipulate tuple vectors with ~500k fields.

Unit tests have been updated.
