### PR TITLE
Removes signature not null precondition in SequenceFileLoader

### DIFF
--- a/src/java/com/twitter/elephantbird/pig/load/SequenceFileLoader.java
+++ b/src/java/com/twitter/elephantbird/pig/load/SequenceFileLoader.java
@@ -15,7 +15,6 @@ import org.apache.commons.cli.OptionBuilder;
 import org.apache.commons.cli.Options;
 import org.apache.commons.cli.ParseException;
 import org.apache.commons.cli.UnrecognizedOptionException;
-import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.io.DataInputBuffer;
 import org.apache.hadoop.io.SequenceFile;
@@ -35,7 +34,6 @@ import org.apache.pig.ResourceSchema.ResourceFieldSchema;
 import org.apache.pig.ResourceStatistics;
 import org.apache.pig.backend.executionengine.ExecException;
 import org.apache.pig.backend.hadoop.executionengine.mapReduceLayer.PigSplit;
-import org.apache.pig.backend.hadoop.executionengine.util.MapRedUtil;
 import org.apache.pig.data.DataByteArray;
 import org.apache.pig.data.Tuple;
 import org.apache.pig.data.TupleFactory;
@@ -287,18 +285,6 @@ public class SequenceFileLoader<K extends Writable, V extends Writable> extends 
      * so we're out of luck here. No casting supported.
      */
     return null;
-  }
-
-  protected void ensureUDFContext(Configuration conf) {
-    Preconditions.checkNotNull(conf, "Configuration is null");
-    if (UDFContext.getUDFContext().isUDFConfEmpty()
-        && conf.get("pig.udf.context") != null) {
-      try {
-        MapRedUtil.setupUDFContext(conf);
-      } catch (IOException e) {
-        throw new RuntimeException(e);
-      }
-    }
   }
 
   @Override

--- a/src/java/com/twitter/elephantbird/pig/store/SequenceFileStorage.java
+++ b/src/java/com/twitter/elephantbird/pig/store/SequenceFileStorage.java
@@ -217,6 +217,14 @@ public class SequenceFileStorage<K extends Writable, V extends Writable> extends
     }
   }
 
+  private void ensureUDFContext(Configuration conf) throws IOException {
+    if (UDFContext.getUDFContext().isUDFConfEmpty()
+      && conf.get("pig.udf.context") != null) {
+      MapRedUtil.setupUDFContext(conf);
+    }
+  }
+
+
   /**
    * Tests validity of Writable class, ensures consistent error message for both key and value
    * tests.


### PR DESCRIPTION
Could someone with more intimate knowledge of how UDF signatures are initialized let me know if this update is safe? This precondition occasionally fails for me with Pig 0.9.2 on the front end.
