### PR TITLE
Fix a classname bug introduced in the recent refactor.

### DIFF
--- a/src/java/com/twitter/elephantbird/pig/load/LzoJsonLoader.java
+++ b/src/java/com/twitter/elephantbird/pig/load/LzoJsonLoader.java
@@ -1,9 +1,9 @@
 package com.twitter.elephantbird.pig.load;
 
-import com.twitter.elephantbird.mapreduce.input.LzoInputFormat;
+import com.twitter.elephantbird.mapreduce.input.LzoTextInputFormat;
 
 public class LzoJsonLoader extends JsonLoader {
   public LzoJsonLoader() {
-    super(LzoInputFormat.class.getName());
+    super(LzoTextInputFormat.class.getName());
   }
 }


### PR DESCRIPTION
When refactoring JsonLoader it was changed to use any InputFormat. LzoInputFormat became a convenience class that simply sets the InputFormat for you. This fixes LzoInputFormat to use LzoTextInputFormat (rather than LzoInputFormat).

Note: LzoInputFormat used to use LzoJsonInputFormat. I believe having the pig loader parse JSON is preferable over the LZO-specific InputFormat. A potential refactor is moving JSON parsing into an InputFormat so JSON parsing happens in just one place.
