### PR TITLE
Thrift : fix for isBuffer check

### DIFF
--- a/src/java/com/twitter/elephantbird/thrift/TStructDescriptor.java
+++ b/src/java/com/twitter/elephantbird/thrift/TStructDescriptor.java
@@ -208,7 +208,7 @@ public class TStructDescriptor {
         // until then a partial work around that works only if
         // the field is not inside a container.
         isBuffer_ =
-          ByteBuffer.class == ThriftUtils.getFieldType(enclosingClass, fieldName);
+          ThriftUtils.getFieldType(enclosingClass, fieldName) != String.class;
       } else {
         isBuffer_= false;
       }


### PR DESCRIPTION
update the check to determine if a field is String or a buffer.
for a buffer type, return type could be a ByteBuffer
or a byte[] depending on the Thrift version, so unreliable.

the patch instead checks to see if the return type is a String.

There is a unit test for this. but this regression could be caught only by using different versions of Thrift.
This is a regression introduced in pull #163 .
