### PR TITLE
Refactors VectorWritableConverter to support transformation of vector data on store

### DIFF
--- a/src/java/com/twitter/elephantbird/pig/mahout/VectorWritableConverter.java
+++ b/src/java/com/twitter/elephantbird/pig/mahout/VectorWritableConverter.java
@@ -32,6 +32,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import com.twitter.elephantbird.pig.load.SequenceFileLoader;
 import com.twitter.elephantbird.pig.util.AbstractWritableConverter;
+import com.twitter.elephantbird.pig.util.PigCounterHelper;
 import com.twitter.elephantbird.pig.util.PigUtil;
 
 /**
@@ -125,6 +126,19 @@ import com.twitter.elephantbird.pig.util.PigUtil;
  * @author Andy Schlaikjer
  */
 public class VectorWritableConverter extends AbstractWritableConverter<VectorWritable> {
+  /**
+   * Hadoop job counters used by {@link VectorWritableConverter}.
+   *
+   * @author Andy Schlaikjer
+   */
+  public static enum Counter {
+    /**
+     * The number of input sparse vector entry indices found to be out-of-bounds during Tuple to
+     * Vector conversion.
+     */
+    INDEX_OUT_OF_BOUNDS;
+  }
+
   private static final String CARDINALITY_PARAM = "cardinality";
   private static final String DENSE_PARAM = "dense";
   private static final String SPARSE_PARAM = "sparse";
@@ -132,6 +146,7 @@ public class VectorWritableConverter extends AbstractWritableConverter<VectorWri
   private static final String FLOAT_PRECISION_PARAM = "floatPrecision";
   private final TupleFactory tupleFactory = TupleFactory.getInstance();
   private final BagFactory bagFactory = BagFactory.getInstance();
+  private final PigCounterHelper counterHelper = new PigCounterHelper();
   private final boolean dense;
   private final boolean sparse;
   private final Integer cardinality;
@@ -369,51 +384,17 @@ public class VectorWritableConverter extends AbstractWritableConverter<VectorWri
   protected VectorWritable toWritable(Tuple value) throws IOException {
     Preconditions.checkNotNull(value, "Tuple is null");
     Vector v = null;
-    if (isSparseVector(value)) {
-
-      // found sparse vector tuple
-      Preconditions.checkState(!dense, "Expecting dense vector but found sparse vector");
-      int size = 0;
-      DataBag entries = null;
-      if (value.size() == 2) {
-        size = (Integer) value.get(0);
-        if (cardinality != null) {
-          Preconditions.checkState(cardinality == size,
-              "Expecting cardinality %s but found cardinality %s", cardinality, size);
-        }
-        entries = (DataBag) value.get(1);
-      } else {
-        Preconditions.checkNotNull(cardinality, "Cardinality is undefined");
-        size = cardinality;
-        entries = (DataBag) value.get(0);
-      }
-      v = new RandomAccessSparseVector(size);
-      for (Tuple entry : entries) {
-        validateSparseVectorEntry(entry);
-        v.setQuick((Integer) entry.get(0), ((Number) entry.get(1)).doubleValue());
-      }
-      if (sequential) {
-        v = new SequentialAccessSparseVector(v);
-      }
-
+    if (isSparseVectorData(value)) {
+      v = convertSparseVectorDataToVector(value);
     } else {
-
-      // found dense vector tuple
-      Preconditions.checkState(!sparse, "Expecting sparse vector but found dense vector");
-      validateDenseVector(value);
-      double[] values = new double[value.size()];
-      for (int i = 0; i < values.length; ++i) {
-        values[i] = ((Number) value.get(i)).doubleValue();
-      }
-      v = new DenseVector(values, true);
-
+      validateDenseVectorData(value);
+      v = convertDenseVectorDataToVector(value);
     }
-
     writable.set(v);
     return writable;
   }
 
-  private static boolean isSparseVector(Tuple value) throws IOException {
+  private static boolean isSparseVectorData(Tuple value) throws IOException {
     assertNotNull(value, "Tuple is null");
     if ((1 == value.size() && DataType.BAG == value.getType(0))
         || (2 == value.size() && DataType.INTEGER == value.getType(0) && DataType.BAG == value
@@ -422,18 +403,101 @@ public class VectorWritableConverter extends AbstractWritableConverter<VectorWri
     return false;
   }
 
-  private static void validateSparseVectorEntry(Tuple value) throws IOException {
+  private Vector convertSparseVectorDataToVector(Tuple value) throws IOException {
+    Vector v;
+
+    // determine output vector size and fetch bag containing entries from input
+    int size = 0;
+    DataBag entries = null;
+    if (value.size() == 2) {
+      // cardinality defined by input
+      size = (Integer) value.get(0);
+      if (cardinality != null) {
+        // cardinality defined by VectorWritableConverter instance
+        size = cardinality;
+      }
+      entries = (DataBag) value.get(1);
+    } else {
+      Preconditions.checkNotNull(cardinality, "Cardinality is undefined");
+      size = cardinality;
+      entries = (DataBag) value.get(0);
+    }
+
+    // create vector, allowing conversion of sparse input vector data to dense output vector
+    if (dense) {
+      // TODO(Andy Schlaikjer): Test for OOM before it happens
+      v = new DenseVector(size);
+    } else {
+      // more efficient to build sparse vector with this impl
+      v = new RandomAccessSparseVector(size);
+    }
+
+    // populate vector
+    for (Tuple entry : entries) {
+      validateSparseVectorEntryData(entry);
+      int i = (Integer) entry.get(0);
+      // check index bounds
+      if (i < 0 || i >= size) {
+        counterHelper.incrCounter(Counter.INDEX_OUT_OF_BOUNDS, 1);
+        continue;
+      }
+      double n = ((Number) entry.get(1)).doubleValue();
+      v.setQuick(i, n);
+    }
+
+    // convert to (sparse) sequential vector if requested
+    if (sequential) {
+      v = new SequentialAccessSparseVector(v);
+    }
+
+    return v;
+  }
+
+  private static void validateSparseVectorEntryData(Tuple value) throws IOException {
     assertNotNull(value, "Tuple is null");
     assertTupleLength(2, value.size(), "tuple");
     assertFieldTypeEquals(DataType.INTEGER, value.getType(0), "tuple[0]");
     assertFieldTypeIsNumeric(value.getType(1), "tuple[1]");
   }
 
-  private static void validateDenseVector(Tuple value) throws IOException {
+  private static void validateDenseVectorData(Tuple value) throws IOException {
     assertNotNull(value, "Tuple is null");
     for (int i = 0; i < value.size(); ++i) {
       assertFieldTypeIsNumeric(value.getType(i), "tuple[" + i + "]");
     }
+  }
+
+  private Vector convertDenseVectorDataToVector(Tuple value) throws IOException {
+    Vector v;
+
+    // determine output vector size
+    int size = value.size();
+    int minSize = size;
+    if (cardinality != null && cardinality != size) {
+      // cardinality specified on construction overrides instance cardinality
+      size = cardinality;
+      if (minSize > size) {
+        minSize = size;
+      }
+    }
+
+    // allow conversion of dense vector data to sparse vector
+    if (sparse) {
+      // this ctor used to pre-alloc space for entries
+      v = new RandomAccessSparseVector(size, size);
+      for (int i = 0; i < minSize; ++i) {
+        v.setQuick(i, ((Number) value.get(i)).doubleValue());
+      }
+    } else {
+      double[] values = new double[size];
+      for (int i = 0; i < minSize; ++i) {
+        values[i] = ((Number) value.get(i)).doubleValue();
+      }
+      // this ctor uses values directly, no copying performed
+      v = new DenseVector(values, true);
+    }
+
+    return v;
   }
 
   private static void assertNotNull(Object value, String msg, Object... values) throws IOException {

--- a/src/test/com/twitter/elephantbird/pig/mahout/TestDenseVectorWritableConverter.java
+++ b/src/test/com/twitter/elephantbird/pig/mahout/TestDenseVectorWritableConverter.java
@@ -8,7 +8,6 @@ import org.apache.mahout.math.VectorWritable;
 import org.junit.Assert;
 import org.junit.Test;
 
-import com.twitter.elephantbird.pig.mahout.VectorWritableConverter;
 import com.twitter.elephantbird.pig.util.AbstractTestWritableConverter;
 
 /**
@@ -29,7 +28,7 @@ public class TestDenseVectorWritableConverter extends
 
   protected void testLoadSchema(String writableConverterClassArgs, String expectedSchema)
       throws IOException {
-    registerReadQuery(writableConverterClassArgs, null);
+    registerReadQuery(tempFilename, writableConverterClassArgs, null);
     Assert.assertEquals(String.format("{key: int,value: %s}", expectedSchema),
         String.valueOf(pigServer.dumpSchema("A")));
   }
@@ -87,5 +86,13 @@ public class TestDenseVectorWritableConverter extends
   public void testLoadConversionSchema() throws IOException {
     registerReadQuery("-- -sparse", null);
     validate(new String[] { "(3,{(0,1.0),(1,2.0),(2,3.0)})" }, pigServer.openIterator("A"));
+  }
+
+  @Test
+  public void testSparseToDense() throws IOException {
+    registerReadQuery("-- -sparse", null);
+    registerWriteQuery(tempFilename + "-2", "-- -dense");
+    registerReadQuery(tempFilename + "-2");
+    validate(pigServer.openIterator("A"));
   }
 }


### PR DESCRIPTION
Currently, vector data can be transformed on load to sparse or dense tuple
vector formats, regardless of the format of the data being loaded. However, on
store, a similar transformation could not be performed: Given sparse vector
tuple data, create and store DenseVector instances, or given dense vector tuple
data, create and store *SparseVector instances. This patch updates to allow this
type of conversion on store.
