### PR TITLE
setClassConf() interface

### DIFF
--- a/examples/src/java/com/twitter/elephantbird/examples/ProtobufMRExample.java
+++ b/examples/src/java/com/twitter/elephantbird/examples/ProtobufMRExample.java
@@ -66,9 +66,11 @@ public class ProtobufMRExample {
 
     job.setInputFormatClass(TextInputFormat.class);
     if (conf.get("proto.test.format", "B64Line").equals("Block")) {
-      job.setOutputFormatClass(LzoProtobufBlockOutputFormat.getOutputFormatClass(Age.class, job.getConfiguration()));
+      LzoProtobufBlockOutputFormat.setClassConf(Age.class, job.getConfiguration());
+      job.setOutputFormatClass(LzoProtobufBlockOutputFormat.class);
     } else { // assume B64Line
-      job.setOutputFormatClass(LzoProtobufB64LineOutputFormat.getOutputFormatClass(Age.class, job.getConfiguration()));
+      LzoProtobufB64LineOutputFormat.setClassConf(Age.class, job.getConfiguration());
+      job.setOutputFormatClass(LzoProtobufB64LineOutputFormat.class);
     }
 
     FileInputFormat.setInputPaths(job, new Path(args[0]));

--- a/examples/src/java/com/twitter/elephantbird/examples/ThriftMRExample.java
+++ b/examples/src/java/com/twitter/elephantbird/examples/ThriftMRExample.java
@@ -62,9 +62,11 @@ public class ThriftMRExample {
 
     job.setInputFormatClass(TextInputFormat.class);
     if (conf.get("thrift.test.format", "B64Line").equals("Block")) {
-      job.setOutputFormatClass(LzoThriftBlockOutputFormat.getOutputFormatClass(Age.class, job.getConfiguration()));
+      LzoThriftBlockOutputFormat.setClassConf(Age.class, job.getConfiguration());
+      job.setOutputFormatClass(LzoThriftBlockOutputFormat.class);
     } else { // assume B64Line
-      job.setOutputFormatClass(LzoThriftB64LineOutputFormat.getOutputFormatClass(Age.class, job.getConfiguration()));
+      LzoThriftB64LineOutputFormat.setClassConf(Age.class, job.getConfiguration());
+      job.setOutputFormatClass(LzoThriftB64LineOutputFormat.class);
     }
 
     FileInputFormat.setInputPaths(job, new Path(args[0]));

--- a/src/java/com/twitter/elephantbird/cascading2/scheme/LzoProtobufScheme.java
+++ b/src/java/com/twitter/elephantbird/cascading2/scheme/LzoProtobufScheme.java
@@ -41,9 +41,8 @@ public class LzoProtobufScheme<M extends Message> extends
 
   @Override
   public void sinkConfInit(HadoopFlowProcess hfp, Tap tap, JobConf conf) {
-    conf.setOutputFormat(
-      DeprecatedLzoProtobufBlockOutputFormat.getOutputFormatClass(protoClass, conf)
-    );
+    DeprecatedLzoProtobufBlockOutputFormat.setClassConf(protoClass, conf);
+    conf.setOutputFormat(DeprecatedLzoProtobufBlockOutputFormat.class);
   }
 
   @Override

--- a/src/java/com/twitter/elephantbird/cascading2/scheme/LzoThriftScheme.java
+++ b/src/java/com/twitter/elephantbird/cascading2/scheme/LzoThriftScheme.java
@@ -36,9 +36,8 @@ public class LzoThriftScheme<M extends TBase<?,?>> extends
 
   @Override
   public void sinkConfInit(HadoopFlowProcess hfp, Tap tap, JobConf conf) {
-    conf.setOutputFormat(
-      DeprecatedLzoThriftBlockOutputFormat.getOutputFormatClass(thriftClass, conf)
-    );
+    DeprecatedLzoThriftBlockOutputFormat.setClassConf(thriftClass, conf);
+    conf.setOutputFormat(DeprecatedLzoThriftBlockOutputFormat.class);
   }
 
   protected ThriftWritable<M> prepareBinaryWritable() {

--- a/src/java/com/twitter/elephantbird/mapred/input/DeprecatedInputFormatWrapper.java
+++ b/src/java/com/twitter/elephantbird/mapred/input/DeprecatedInputFormatWrapper.java
@@ -59,7 +59,7 @@ public class DeprecatedInputFormatWrapper<K, V> implements org.apache.hadoop.map
    */
   public static void setInputFormat(Class<?> realInputFormatClass, JobConf jobConf) {
     jobConf.setInputFormat(DeprecatedInputFormatWrapper.class);
-    HadoopUtils.setInputFormatClass(jobConf, CLASS_CONF_KEY, realInputFormatClass);
+    HadoopUtils.setClassConf(jobConf, CLASS_CONF_KEY, realInputFormatClass);
   }
 
   @SuppressWarnings("unchecked")

--- a/src/java/com/twitter/elephantbird/mapred/input/DeprecatedLzoProtobufBlockInputFormat.java
+++ b/src/java/com/twitter/elephantbird/mapred/input/DeprecatedLzoProtobufBlockInputFormat.java
@@ -4,6 +4,8 @@ import com.google.protobuf.Message;
 import com.twitter.elephantbird.mapreduce.io.ProtobufWritable;
 import com.twitter.elephantbird.util.TypeRef;
 import com.twitter.elephantbird.util.Protobufs;
+
+import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.mapred.FileSplit;
 import org.apache.hadoop.mapred.InputSplit;
 import org.apache.hadoop.mapred.JobConf;
@@ -45,15 +47,11 @@ public class DeprecatedLzoProtobufBlockInputFormat<M extends Message, W extends 
   }
 
   /**
-   * Returns {@link DeprecatedLzoProtobufBlockInputFormat} class.
-   * Sets an internal configuration in jobConf so that remote Tasks
-   * instantiate appropriate object based on protoClass.
+   * Stores supplied class name in configuration. This configuration is
+   * read on the remote tasks to initialize the input format correctly.
    */
-  @SuppressWarnings("unchecked")
-  public static <M extends Message> Class<DeprecatedLzoProtobufBlockInputFormat>
-     getInputFormatClass(Class<M> protoClass, JobConf jobConf) {
-    Protobufs.setClassConf(jobConf, DeprecatedLzoProtobufBlockInputFormat.class, protoClass);
-    return DeprecatedLzoProtobufBlockInputFormat.class;
+  public static void setClassConf(Class<? extends Message> protoClass, Configuration conf) {
+    Protobufs.setClassConf(conf, DeprecatedLzoProtobufBlockInputFormat.class, protoClass);
   }
 
   @Override

--- a/src/java/com/twitter/elephantbird/mapred/input/DeprecatedLzoThriftB64LineInputFormat.java
+++ b/src/java/com/twitter/elephantbird/mapred/input/DeprecatedLzoThriftB64LineInputFormat.java
@@ -23,28 +23,12 @@ public class DeprecatedLzoThriftB64LineInputFormat<M extends TBase<?, ?>>
     extends DeprecatedLzoInputFormat<LongWritable, ThriftWritable<M>> {
 
   /**
-   * Returns DeprecatedLzoThriftB64LineInputFormat class for setting up a job.
-   * Sets an internal configuration in jobConf so that Task instantiates
-   * appropriate object for this generic class based on thriftClass
+   * Stores supplied class name in configuration. This configuration is
+   * read on the remote tasks to initialize the input format correctly.
    */
-  //@SuppressWarnings("unchecked")
-  public static <M extends TBase<?, ?>> Class<DeprecatedLzoThriftB64LineInputFormat>
-     getInputFormatClass(Class<M> thriftClass, Configuration jobConf) {
-    return getInputFormatClass(
-        DeprecatedLzoThriftB64LineInputFormat.class, thriftClass, jobConf);
+  public static void setClassConf(Class<? extends TBase<?, ?>> thriftClass, Configuration conf) {
+    ThriftUtils.setClassConf(conf, DeprecatedLzoThriftB64LineInputFormat.class, thriftClass);
   }
-
-  /**
-   * Sets an internal configuration in jobConf so that Task instantiates
-   * appropriate object for this generic class based on thriftClass.
-   * Returns formatClass.
-   */
-  public static <T extends InputFormat, M extends TBase<?, ?>> Class<T> getInputFormatClass(
-      Class<T> formatClass, Class<M> thriftClass, Configuration jobConf) {
-    ThriftUtils.setClassConf(jobConf, formatClass, thriftClass);
-    return formatClass;
-  }
-
 
   /**
    * Return a DeprecatedLzoThriftB64LineRecordReader to handle the work.

--- a/src/java/com/twitter/elephantbird/mapred/output/DeprecatedLzoProtobufBlockOutputFormat.java
+++ b/src/java/com/twitter/elephantbird/mapred/output/DeprecatedLzoProtobufBlockOutputFormat.java
@@ -1,7 +1,6 @@
 package com.twitter.elephantbird.mapred.output;
 
 import com.twitter.elephantbird.mapreduce.io.ProtobufBlockWriter;
-import com.twitter.elephantbird.mapreduce.io.ProtobufConverter;
 import com.twitter.elephantbird.mapreduce.io.ProtobufWritable;
 import com.twitter.elephantbird.util.TypeRef;
 import com.twitter.elephantbird.util.Protobufs;
@@ -22,12 +21,13 @@ import java.io.IOException;
  */
 public class DeprecatedLzoProtobufBlockOutputFormat<M extends Message>
     extends DeprecatedLzoOutputFormat<NullWritable, ProtobufWritable<M>> {
-  @SuppressWarnings("unchecked")
-  public static <M extends Message> Class<DeprecatedLzoProtobufBlockOutputFormat>
-     getOutputFormatClass(Class<M> protoClass, Configuration jobConf) {
 
-    Protobufs.setClassConf(jobConf, DeprecatedLzoProtobufBlockOutputFormat.class, protoClass);
-    return DeprecatedLzoProtobufBlockOutputFormat.class;
+  /**
+   * Stores supplied class name in configuration. This configuration is
+   * read on the remote tasks to initialize the output format correctly.
+   */
+  public static void setClassConf(Class<? extends Message> protoClass, Configuration conf) {
+    Protobufs.setClassConf(conf, DeprecatedLzoProtobufBlockOutputFormat.class, protoClass);
   }
 
   @Override

--- a/src/java/com/twitter/elephantbird/mapred/output/DeprecatedLzoThriftB64LineOutputFormat.java
+++ b/src/java/com/twitter/elephantbird/mapred/output/DeprecatedLzoThriftB64LineOutputFormat.java
@@ -21,12 +21,13 @@ import java.io.IOException;
  */
 public class DeprecatedLzoThriftB64LineOutputFormat<M extends TBase<?, ?>>
     extends DeprecatedLzoOutputFormat<NullWritable, ThriftWritable<M>> {
-  @SuppressWarnings("unchecked")
-  public static <M extends TBase<?, ?>> Class<DeprecatedLzoThriftB64LineOutputFormat>
-     getOutputFormatClass(Class<M> thriftClass, Configuration jobConf) {
 
-    ThriftUtils.setClassConf(jobConf, DeprecatedLzoThriftB64LineOutputFormat.class, thriftClass);
-    return DeprecatedLzoThriftB64LineOutputFormat.class;
+  /**
+   * Stores supplied class name in configuration. This configuration is
+   * read on the remote tasks to initialize the output format correctly.
+   */
+  public static void setClassConf(Class<? extends TBase<?, ?>> thriftClass, Configuration conf) {
+    ThriftUtils.setClassConf(conf, DeprecatedLzoThriftB64LineOutputFormat.class, thriftClass);
   }
 
   @Override

--- a/src/java/com/twitter/elephantbird/mapred/output/DeprecatedLzoThriftBlockOutputFormat.java
+++ b/src/java/com/twitter/elephantbird/mapred/output/DeprecatedLzoThriftBlockOutputFormat.java
@@ -20,12 +20,13 @@ import java.io.IOException;
  */
 public class DeprecatedLzoThriftBlockOutputFormat<M extends TBase<?, ?>>
     extends DeprecatedLzoOutputFormat<NullWritable, ThriftWritable<M>> {
-  @SuppressWarnings("unchecked")
-  public static <M extends TBase<?, ?>> Class<DeprecatedLzoThriftBlockOutputFormat>
-     getOutputFormatClass(Class<M> thriftClass, Configuration jobConf) {
 
-    ThriftUtils.setClassConf(jobConf, DeprecatedLzoThriftBlockOutputFormat.class, thriftClass);
-    return DeprecatedLzoThriftBlockOutputFormat.class;
+  /**
+   * Stores supplied class name in configuration. This configuration is
+   * read on the remote tasks to initialize the output format correctly.
+   */
+  public static void setClassConf(Class<? extends TBase<?, ?>> thriftClass, Configuration conf) {
+    ThriftUtils.setClassConf(conf, DeprecatedLzoThriftBlockOutputFormat.class, thriftClass);
   }
 
   @Override

--- a/src/java/com/twitter/elephantbird/mapreduce/input/LzoProtobufB64LineInputFormat.java
+++ b/src/java/com/twitter/elephantbird/mapreduce/input/LzoProtobufB64LineInputFormat.java
@@ -1,7 +1,5 @@
 package com.twitter.elephantbird.mapreduce.input;
 
-import org.apache.hadoop.conf.Configuration;
-
 import com.google.protobuf.Message;
 import com.twitter.elephantbird.util.TypeRef;
 
@@ -10,14 +8,11 @@ import com.twitter.elephantbird.util.TypeRef;
  * Data is expected to be one base64 encoded serialized protocol buffer per line.
  * <br><br>
  *
- * Do not use LzoProtobufB64LineInputFormat.class directly for setting
- * InputFormat class for a job. Use getInputFormatClass() or newInstance(typeRef) instead.
- *
- * <p>
  * A small fraction of bad records are tolerated. See {@link LzoRecordReader}
  * for more information on error handling.
+ *
+ * @Deprecated use {@link MultiInputFormat}
  */
-
 public class LzoProtobufB64LineInputFormat<M extends Message> extends MultiInputFormat<M> {
 
   public LzoProtobufB64LineInputFormat() {
@@ -25,20 +20,6 @@ public class LzoProtobufB64LineInputFormat<M extends Message> extends MultiInput
 
   public LzoProtobufB64LineInputFormat(TypeRef<M> typeRef) {
     super(typeRef);
-  }
-
-  /**
-   * Returns {@link LzoProtobufB64LineInputFormat} class.
-   * Sets an internal configuration in jobConf so that remote Tasks
-   * instantiate appropriate object based on protoClass.
-   *
-   * @Deprecated Use {@link MultiInputFormat#setInputFormatClass(Class, org.apache.hadoop.mapreduce.Job)
-   */
-  @SuppressWarnings("rawtypes")
-  public static <M extends Message> Class<LzoProtobufB64LineInputFormat>
-     getInputFormatClass(Class<M> protoClass, Configuration jobConf) {
-    setClassConf(protoClass, jobConf);
-    return LzoProtobufB64LineInputFormat.class;
   }
 
   public static<M extends Message> LzoProtobufB64LineInputFormat<M> newInstance(TypeRef<M> typeRef) {

--- a/src/java/com/twitter/elephantbird/mapreduce/input/LzoProtobufBlockInputFormat.java
+++ b/src/java/com/twitter/elephantbird/mapreduce/input/LzoProtobufBlockInputFormat.java
@@ -1,7 +1,5 @@
 package com.twitter.elephantbird.mapreduce.input;
 
-import org.apache.hadoop.conf.Configuration;
-
 import com.google.protobuf.Message;
 import com.twitter.elephantbird.util.TypeRef;
 
@@ -10,14 +8,11 @@ import com.twitter.elephantbird.util.TypeRef;
  * the ProtobufBlockWriter to write your data, this input format can read it.
  * <br> <br>
  *
- * Do not use LzoProtobufBlockInputFormat.class directly for setting
- * InputFormat class for a job. Use getInputFormatClass() instead.<p>
- *
- * <p>
  * A small fraction of bad records are tolerated. See {@link LzoRecordReader}
  * for more information on error handling.
+ *
+ * @Deprecated use {@link MultiInputFormat}
  */
-
 public class LzoProtobufBlockInputFormat<M extends Message> extends MultiInputFormat<M> {
 
   public LzoProtobufBlockInputFormat() {
@@ -25,20 +20,6 @@ public class LzoProtobufBlockInputFormat<M extends Message> extends MultiInputFo
 
   public LzoProtobufBlockInputFormat(TypeRef<M> typeRef) {
     super(typeRef);
-  }
-
-  /**
-   * Returns {@link LzoProtobufBlockInputFormat} class.
-   * Sets an internal configuration in jobConf so that remote Tasks
-   * instantiate appropriate object based on protoClass.
-   *
-   * @Deprecated Use {@link MultiInputFormat#setInputFormatClass(Class, org.apache.hadoop.mapreduce.Job)
-   */
-  @SuppressWarnings("unchecked")
-  public static <M extends Message> Class<LzoProtobufBlockInputFormat>
-     getInputFormatClass(Class<M> protoClass, Configuration jobConf) {
-    setClassConf(protoClass, jobConf);
-    return LzoProtobufBlockInputFormat.class;
   }
 
   public static<M extends Message> LzoProtobufBlockInputFormat<M> newInstance(TypeRef<M> typeRef) {

--- a/src/java/com/twitter/elephantbird/mapreduce/input/LzoThriftB64LineInputFormat.java
+++ b/src/java/com/twitter/elephantbird/mapreduce/input/LzoThriftB64LineInputFormat.java
@@ -1,6 +1,5 @@
 package com.twitter.elephantbird.mapreduce.input;
 
-import org.apache.hadoop.conf.Configuration;
 import org.apache.thrift.TBase;
 
 import com.twitter.elephantbird.util.TypeRef;
@@ -10,12 +9,10 @@ import com.twitter.elephantbird.util.TypeRef;
  * deserializes that into the Thrift object.
  * Returns <position, thriftObject> pairs. <br><br>
  *
- * Do not use LzoThriftB64LineInputFormat.class directly for setting
- * InputFormat class for a job. Use getInputFormatClass() instead.<p>
- *
- * <p>
  * A small fraction of bad records are tolerated. See {@link LzoRecordReader}
  * for more information on error handling.
+ *
+ * @Deprecated use {@link MultiInputFormat}
  */
 public class LzoThriftB64LineInputFormat<M extends TBase<?, ?>> extends MultiInputFormat<M> {
 
@@ -23,18 +20,5 @@ public class LzoThriftB64LineInputFormat<M extends TBase<?, ?>> extends MultiInp
 
   public LzoThriftB64LineInputFormat(TypeRef<M> typeRef) {
     super(typeRef);
-  }
-
-  /**
-   * Returns {@link LzoThriftB64LineInputFormat} class for setting up a job.
-   * Sets an internal configuration in jobConf so that Task instantiates
-   * appropriate object for this generic class based on thriftClass
-   *
-   * @Deprecated Use {@link MultiInputFormat#setInputFormatClass(Class, org.apache.hadoop.mapreduce.Job)
-   */
-  public static <M extends TBase<?, ?>> Class<LzoThriftB64LineInputFormat>
-     getInputFormatClass(Class<M> thriftClass, Configuration jobConf) {
-    setClassConf(thriftClass, jobConf);
-    return LzoThriftB64LineInputFormat.class;
   }
 }

--- a/src/java/com/twitter/elephantbird/mapreduce/input/LzoThriftBlockInputFormat.java
+++ b/src/java/com/twitter/elephantbird/mapreduce/input/LzoThriftBlockInputFormat.java
@@ -9,10 +9,6 @@ import org.apache.thrift.TBase;
  * Reads Thrift objects written in blocks using LzoThriftBlockOutputFormat
  * <br><br>
  *
- * Do not use LzoThriftBlockInputFormat.class directly for setting
- * InputFormat class for a job. Use getInputFormatClass() instead.
- *
- * <p>
  * A small fraction of bad records are tolerated. See {@link LzoRecordReader}
  * for more information on error handling.
  */
@@ -22,19 +18,5 @@ public class LzoThriftBlockInputFormat<M extends TBase<?, ?>> extends MultiInput
 
   public LzoThriftBlockInputFormat(TypeRef<M> typeRef) {
     super(typeRef);
-  }
-
-  /**
-   * Returns {@link LzoThriftBlockInputFormat} class for setting up a job.
-   * Sets an internal configuration in jobConf so that Task instantiates
-   * appropriate object for this generic class based on thriftClass
-   *
-   * @Deprecated Use {@link MultiInputFormat#setInputFormatClass(Class, org.apache.hadoop.mapreduce.Job)
-   */
-  @SuppressWarnings("unchecked")
-  public static <M extends TBase<?, ?>> Class<LzoThriftBlockInputFormat>
-     getInputFormatClass(Class<M> thriftClass, Configuration jobConf) {
-    setClassConf(thriftClass, jobConf);
-    return LzoThriftBlockInputFormat.class;
   }
 }

--- a/src/java/com/twitter/elephantbird/mapreduce/input/MultiInputFormat.java
+++ b/src/java/com/twitter/elephantbird/mapreduce/input/MultiInputFormat.java
@@ -69,7 +69,7 @@ public class MultiInputFormat<M>
    * read on the remote tasks to initialize the input format correctly.
    */
   public static void setClassConf(Class<?> clazz, Configuration conf) {
-    HadoopUtils.setInputFormatClass(conf, CLASS_CONF_KEY, clazz);
+    HadoopUtils.setClassConf(conf, CLASS_CONF_KEY, clazz);
   }
 
   @SuppressWarnings("unchecked") // return type is runtime dependent

--- a/src/java/com/twitter/elephantbird/mapreduce/output/LzoProtobufB64LineOutputFormat.java
+++ b/src/java/com/twitter/elephantbird/mapreduce/output/LzoProtobufB64LineOutputFormat.java
@@ -16,8 +16,7 @@ import com.twitter.elephantbird.util.TypeRef;
  * This is the class for all base64 encoded, line-oriented protocol buffer based output formats.
  * Data is written as one base64 encoded serialized protocol buffer per line.<br><br>
  *
- * Do not use LzoProtobufB64LineOutputFormat.class directly for setting
- * OutputFormat class for a job. Use getOutputFormatClass() or getInstance() instead.
+ * Do not forget to set Protobuf class using setClassConf().
  */
 
 public class LzoProtobufB64LineOutputFormat<M extends Message> extends LzoOutputFormat<M, ProtobufWritable<M>> {
@@ -34,16 +33,14 @@ public class LzoProtobufB64LineOutputFormat<M extends Message> extends LzoOutput
   }
 
   /**
-   * Returns {@link LzoProtobufBlockOutputFormat} class.
    * Sets an internal configuration in jobConf so that remote Tasks
    * instantiate appropriate object for this generic class based on protoClass
    */
-  @SuppressWarnings("unchecked")
-  public static <M extends Message> Class<LzoProtobufB64LineOutputFormat>
-  getOutputFormatClass(Class<M> protoClass, Configuration jobConf) {
-
-    Protobufs.setClassConf(jobConf, LzoProtobufB64LineOutputFormat.class, protoClass);
-    return LzoProtobufB64LineOutputFormat.class;
+  public static <M extends Message>
+  void setClassConf(Class<M> protoClass, Configuration jobConf) {
+    Protobufs.setClassConf(jobConf,
+                           LzoProtobufB64LineOutputFormat.class,
+                           protoClass);
   }
 
   @Override

--- a/src/java/com/twitter/elephantbird/mapreduce/output/LzoProtobufBlockOutputFormat.java
+++ b/src/java/com/twitter/elephantbird/mapreduce/output/LzoProtobufBlockOutputFormat.java
@@ -16,8 +16,7 @@ import com.twitter.elephantbird.util.TypeRef;
  * Class for all blocked protocol buffer based output formats.  See
  * the ProtobufBlockWriter class for the on-disk format. <br><br>
  *
- * Do not use LzoProtobufBlockOutputFormat.class directly for setting
- * OutputFormat class for a job. Use getOutputFormatClass() or getInstance() instead.
+ * Do not forget to set Protobuf class using setClassConf().
  */
 
 public class LzoProtobufBlockOutputFormat<M extends Message> extends LzoOutputFormat<M, ProtobufWritable<M>> {
@@ -35,16 +34,14 @@ public class LzoProtobufBlockOutputFormat<M extends Message> extends LzoOutputFo
   }
 
   /**
-   * Returns {@link LzoProtobufB64LineOutputFormat} class.
    * Sets an internal configuration in jobConf so that remote Tasks
    * instantiate appropriate object for this generic class based on protoClass
    */
-  @SuppressWarnings("unchecked")
-  public static <M extends Message> Class<LzoProtobufBlockOutputFormat>
-  getOutputFormatClass(Class<M> protoClass, Configuration jobConf) {
-
-    Protobufs.setClassConf(jobConf, LzoProtobufBlockOutputFormat.class, protoClass);
-    return LzoProtobufBlockOutputFormat.class;
+  public static <M extends Message>
+  void setClassConf(Class<M> protoClass, Configuration jobConf) {
+    Protobufs.setClassConf(jobConf,
+                           LzoProtobufBlockOutputFormat.class,
+                           protoClass);
   }
 
   public static<M extends Message> LzoProtobufBlockOutputFormat<M> newInstance(TypeRef<M> typeRef) {

--- a/src/java/com/twitter/elephantbird/mapreduce/output/LzoThriftB64LineOutputFormat.java
+++ b/src/java/com/twitter/elephantbird/mapreduce/output/LzoThriftB64LineOutputFormat.java
@@ -15,8 +15,7 @@ import org.apache.thrift.TBase;
 /**
  * Data is written as one base64 encoded serialized thrift per line. <br><br>
  *
- * Do not use LzoThriftB64LineOutputFormat.class directly for setting
- * OutputFormat class for a job. Use getOutputFormatClass() instead.
+ * Do not forget to set Thrift class using setClassConf().
  */
 public class LzoThriftB64LineOutputFormat<M extends TBase<?, ?>>
     extends LzoOutputFormat<M, ThriftWritable<M>> {
@@ -29,12 +28,15 @@ public class LzoThriftB64LineOutputFormat<M extends TBase<?, ?>>
     typeRef_ = typeRef;
   }
 
-  @SuppressWarnings("unchecked")
-  public static <M extends TBase<?, ?>> Class<LzoThriftB64LineOutputFormat>
-     getOutputFormatClass(Class<M> thriftClass, Configuration jobConf) {
-
-    ThriftUtils.setClassConf(jobConf, LzoThriftB64LineOutputFormat.class, thriftClass);
-    return LzoThriftB64LineOutputFormat.class;
+  /**
+   * Sets an internal configuration in jobConf so that remote Tasks
+   * instantiate appropriate object for this generic class based on thriftClass
+   */
+  public static <M extends TBase<?, ?>>
+  void setClassConf(Class<M> thriftClass, Configuration jobConf) {
+    ThriftUtils.setClassConf(jobConf,
+                             LzoThriftB64LineOutputFormat.class,
+                             thriftClass);
   }
 
   @Override

--- a/src/java/com/twitter/elephantbird/mapreduce/output/LzoThriftBlockOutputFormat.java
+++ b/src/java/com/twitter/elephantbird/mapreduce/output/LzoThriftBlockOutputFormat.java
@@ -15,8 +15,7 @@ import org.apache.thrift.TBase;
 /**
  * Data is written as one base64 encoded serialized thrift per line. <br><br>
  *
- * Do not use LzoThriftB64LineOutputFormat.class directly for setting
- * OutputFormat class for a job. Use getOutputFormatClass() instead.
+ * Do not forget to set Thrift class using setClassConf().
  */
 public class LzoThriftBlockOutputFormat<M extends TBase<?, ?>>
     extends LzoOutputFormat<M, ThriftWritable<M>> {
@@ -29,12 +28,15 @@ public class LzoThriftBlockOutputFormat<M extends TBase<?, ?>>
     typeRef_ = typeRef;
   }
 
-  @SuppressWarnings("unchecked")
-  public static <M extends TBase<?, ?>> Class<LzoThriftBlockOutputFormat>
-     getOutputFormatClass(Class<M> thriftClass, Configuration jobConf) {
-
-    ThriftUtils.setClassConf(jobConf, LzoThriftBlockOutputFormat.class, thriftClass);
-    return LzoThriftBlockOutputFormat.class;
+  /**
+   * Sets an internal configuration in jobConf so that remote Tasks
+   * instantiate appropriate object for this generic class based on thriftClass
+   */
+  public static <M extends TBase<?, ?>>
+  void setClassConf(Class<M> thriftClass, Configuration jobConf) {
+    ThriftUtils.setClassConf(jobConf,
+                             LzoThriftBlockOutputFormat.class,
+                             thriftClass);
   }
 
   public RecordWriter<M, ThriftWritable<M>> getRecordWriter(TaskAttemptContext job)

--- a/src/java/com/twitter/elephantbird/util/HadoopUtils.java
+++ b/src/java/com/twitter/elephantbird/util/HadoopUtils.java
@@ -16,11 +16,11 @@ public class HadoopUtils {
 
   /**
    * MapReduce counters are available only with {@link TaskInputOutputContext},
-   * but most interfaces use super classes, though the actual obejct is a 
+   * but most interfaces use super classes, though the actual obejct is a
    * subclass (e.g. Mapper.Context). <br> <br>
-   * 
+   *
    * This utility method checks the type and returns the appropriate counter.
-   * In the rare (may be unexpected) case where ctx is not a 
+   * In the rare (may be unexpected) case where ctx is not a
    * TaskInputOutputContext, a dummy counter is returned after printing
    * a warning.
    */
@@ -35,13 +35,23 @@ public class HadoopUtils {
   }
 
   /**
+   * @Deprecated use {@link #setClassConf(Configuration, String, Class)}
+   */
+  @Deprecated
+  public static void setInputFormatClass(Configuration  conf,
+                                         String         configKey,
+                                         Class<?>       clazz) {
+    setClassConf(conf, configKey, clazz);
+  }
+
+  /**
    * A helper to set configuration to class name.
    * Throws a RuntimeExcpetion if the
    * configuration is already set to a different class name.
    */
-  public static void setInputFormatClass(Configuration  conf,
-                                         String         configKey,
-                                         Class<?>       clazz) {
+  public static void setClassConf(Configuration  conf,
+                                  String         configKey,
+                                  Class<?>       clazz) {
     String existingClass = conf.get(configKey);
     String className = clazz.getName();
 

--- a/src/java/com/twitter/elephantbird/util/Protobufs.java
+++ b/src/java/com/twitter/elephantbird/util/Protobufs.java
@@ -250,7 +250,7 @@ public class Protobufs {
 
   public static void setClassConf(Configuration jobConf, Class<?> genericClass,
       Class<? extends Message> protoClass) {
-    HadoopUtils.setInputFormatClass(jobConf,
+    HadoopUtils.setClassConf(jobConf,
            CLASS_CONF_PREFIX + genericClass.getName(),
            protoClass);
   }

--- a/src/java/com/twitter/elephantbird/util/ThriftUtils.java
+++ b/src/java/com/twitter/elephantbird/util/ThriftUtils.java
@@ -13,7 +13,7 @@ public class ThriftUtils {
   public static void setClassConf(Configuration jobConf, Class<?> genericClass,
                                   Class<? extends TBase<?, ?>> thriftClass) {
     String configKey = CLASS_CONF_PREFIX + genericClass.getName();
-    HadoopUtils.setInputFormatClass(jobConf, configKey, thriftClass);
+    HadoopUtils.setClassConf(jobConf, configKey, thriftClass);
   }
 
   /**


### PR DESCRIPTION
long pending update to how a Thrift/Protobuf class is set in conf.

previous getInputFormatClass() which sets the conf
is not intuitive. setClassConf() is cleaner and not confusing.

before :

```
job.setInputFormat(LzoFormat.getInputFormatClass(job, ThriftType.class));
// it is odd that get() modifies configuration
```

now:

```
LzoFormat.setClassConf(conf, ThriftType.class);
job.setInputFormat(LzoFormat.class);
```
