### PR TITLE
preserve unknown fields for Thrift + RCFile

### DIFF
--- a/src/java/com/twitter/elephantbird/util/ThriftUtils.java
+++ b/src/java/com/twitter/elephantbird/util/ThriftUtils.java
@@ -195,10 +195,13 @@ public class ThriftUtils {
 
     if (field.getType() == TType.MAP) {
 
+      Field valueField = field.getMapValueField();
       Map<?, ?> map = (Map<?, ?>)value;
+
+      proto.writeByte(innerField.getType());
+      proto.writeByte(valueField.getType());
       proto.writeI32(map.size());
 
-      Field valueField = field.getMapValueField();
       for(Entry<?, ?> entry : map.entrySet()) {
         writeSingleFieldNoTag(proto, innerField, entry.getKey());
         writeSingleFieldNoTag(proto, valueField, entry.getValue());
@@ -207,6 +210,8 @@ public class ThriftUtils {
     } else { // SET or LIST
 
       Collection<?> coll = (Collection<?>)value;
+
+      proto.writeByte(innerField.getType());
       proto.writeI32(coll.size());
 
       for(Object v : coll) {
@@ -278,9 +283,12 @@ public class ThriftUtils {
 
     // collection or a map:
 
-    int nEntries = proto.readI32();
 
     if (field.getType() == TType.MAP) {
+
+      proto.readByte();
+      proto.readByte();
+      int nEntries = proto.readI32();
 
       Map<Object, Object> map = Maps.newHashMap();
       Field valueField = field.getMapValueField();
@@ -292,6 +300,9 @@ public class ThriftUtils {
       return map;
 
     } else { // SET or LIST
+
+      proto.readByte();
+      int nEntries = proto.readI32();
 
       for(int i=0; i<nEntries; i++) {
         coll.add(readFieldNoTag(proto, innerField));

--- a/src/test/com/twitter/elephantbird/pig/load/TestRCFileProtobufStorage.java
+++ b/src/test/com/twitter/elephantbird/pig/load/TestRCFileProtobufStorage.java
@@ -90,11 +90,11 @@ public class TestRCFileProtobufStorage {
   @Test
   public void testRCFileStorage() throws Exception {
     /* create a directory with two rcfiles :
-     *  - one created with normal Person objects using Pig storage.
+     *  - one created with normal Person objects using RCFileProtobufPigStorage.
      *  - other with PersonWithoutEmail (for testing unknown fields)
      *    using the same objects as the first one.
      *
-     * Then load both files using Pig loader.
+     * Then load both files using RCFileProtobufPigLoader
      */
 
     // write to rcFile using RCFileProtobufStorage

--- a/src/thrift/test.thrift
+++ b/src/thrift/test.thrift
@@ -20,6 +20,14 @@ struct TestPerson {
   2: map<TestPhoneType, string>   phones, // for testing enum keys in maps.
 }
 
+/* TestPerson, plus couple more traits */
+struct TestPersonExtended {
+  1: TestName                     name,
+  2: map<TestPhoneType, string>   phones,
+  3: string                       email,
+  4: TestName                     friend
+}
+
 struct TestIngredient {
   1: string name,
   2: string color,


### PR DESCRIPTION
preserve unknown fields when user writes Thrift  serialized bytes rather than a Thrift object.
Unit test is updated.
