### PR TITLE
fix thrift schema handling for 'struct in a map' 

### DIFF
--- a/src/java/com/twitter/elephantbird/pig/util/ThriftToPig.java
+++ b/src/java/com/twitter/elephantbird/pig/util/ThriftToPig.java
@@ -242,12 +242,7 @@ public class ThriftToPig<M extends TBase<?, ?>> {
 
     try {
       for(Field field : tDesc.getFields()) {
-        String fieldName = field.getName();
-        if (field.isStruct()) {
-          schema.add(new FieldSchema(fieldName, toSchema(field.gettStructDescriptor()), DataType.TUPLE));
-        } else {
-          schema.add(singleFieldToFieldSchema(fieldName, field));
-        }
+        schema.add(singleFieldToFieldSchema(field.getName(), field));
       }
     } catch (FrontendException t) {
       throw new RuntimeException(t);
@@ -255,9 +250,15 @@ public class ThriftToPig<M extends TBase<?, ?>> {
 
     return schema;
   }
-  //TODO we should probably implement better naming, the current system is pretty nonsensical now
+
+  /**
+   * return {@link FieldSchema} for a given field.
+   */
   private static FieldSchema singleFieldToFieldSchema(String fieldName, Field field) throws FrontendException {
+    //TODO we should probably implement better naming, the current system is pretty nonsensical now
     switch (field.getType()) {
+      case TType.STRUCT:
+        return new FieldSchema(fieldName, toSchema(field.gettStructDescriptor()), DataType.TUPLE);
       case TType.LIST:
         return new FieldSchema(fieldName, singleFieldToTupleSchema(fieldName + "_tuple", field.getListElemField()), DataType.BAG);
       case TType.SET:

--- a/src/test/com/twitter/elephantbird/pig/piggybank/TestThriftToPig.java
+++ b/src/test/com/twitter/elephantbird/pig/piggybank/TestThriftToPig.java
@@ -272,6 +272,11 @@ public class TestThriftToPig {
   }
 
   @Test
+  public void structInMapTest() throws FrontendException {
+      nestedInListTestHelper("com.twitter.elephantbird.thrift.test.TestStructInMap","name:chararray,names:map[(name: (first_name: chararray,last_name: chararray),phones: map[chararray])]");
+  }
+
+  @Test
   public void mapInListTest() throws FrontendException {
     nestedInListTestHelper("com.twitter.elephantbird.thrift.test.TestMapInList","name:chararray,names:bag{t:tuple(names_tuple:map[chararray])}");
   }
@@ -286,16 +291,8 @@ public class TestThriftToPig {
     Schema schema=ThriftToPig.toSchema(typeRef_.getRawClass());
     Schema oldSchema = Schema.getPigSchema(new ResourceSchema(schema));
     assertTrue(Schema.equals(schema, oldSchema, false, true));
-    //this is necessary because in pig8, Utils.getSchemaFromString throws a ParseException,
-    //but this doesn't exist in Pig9
-    try {
-      Schema expectedSchema=Utils.getSchemaFromString(expSchema);
-      assertTrue(Schema.equals(schema, expectedSchema, false, true));
-    } catch (Exception e) {
-      System.out.println("Error thrown!");
-      System.out.println(e.getMessage());
-      System.out.println(e.getStackTrace());
-      assertTrue(false);
-    }
+    Schema expectedSchema=Utils.getSchemaFromString(expSchema);
+    assertTrue("expected : " + expSchema + " got " +  schema.toString(),
+               Schema.equals(schema, expectedSchema, false, true));
   }
 }

--- a/src/thrift/test.thrift
+++ b/src/thrift/test.thrift
@@ -98,6 +98,11 @@ struct TestSetInMap {
   2: map<string,set<string>> names,
 }
 
+struct TestStructInMap {
+  1: string name,
+  2: map<string,TestPerson> names,
+}
+
 union TestUnion {
   1: string stringType,
   2: i32    i32Type,


### PR DESCRIPTION
singleField->FieldSchema should handle Struct also.
fixes the case where a map's value is a struct.
