### PR TITLE
Change the org for protobuf from com.google to com.google.protobuf

### DIFF
--- a/ivy.xml
+++ b/ivy.xml
@@ -10,7 +10,7 @@
       <exclude org="log4j"/>
       <exclude org="org.apache.hadoop"/>
     </dependency>
-    <dependency org="com.google" name="protobuf-java" rev="${protobuf-java.version}"/>
+    <dependency org="com.google.protobuf" name="protobuf-java" rev="${protobuf-java.version}"/>
     <dependency org="com.google.guava" name="guava" rev="${guava.version}"/>
     <dependency org="com.googlecode.json-simple" name="json-simple" rev="${json-simple.version}"/>
     <dependency org="com.hadoop" name="hadoop-lzo" rev="${hadoop-lzo.version}"/>


### PR DESCRIPTION
I'm trying to build a project that is slated for open source outside Twitter. I'm running into the problem that elephant-bird depends on protobuf and none of the standard maven repositories have it under the same name. EB depends on org="com.google" but all the PB artifacts are published under org="com.google.protobuf". 
The reason this works internally is because we have a locally published protobuf under the wrong org name in artifactory.

It seems others have the same issue: https://github.com/kevinweil/elephant-bird/issues/150
