### PR TITLE
Json work (Jive Software)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@
 .settings
 build
 eclipse-bin
+out/

--- a/ivy.xml
+++ b/ivy.xml
@@ -38,7 +38,8 @@
     <dependency org="org.apache.mahout" name="mahout-core" rev="${mahout.version}" transitive="false"/>
     <dependency org="org.apache.mahout" name="mahout-math" rev="${mahout.version}" transitive="false"/>
     <dependency org="org.apache.hcatalog" name="hcatalog" rev="0.5.0-dev" transitive="false"/>
-    <exclude org="javax.jms"/>
+    <dependency org="org.codehaus.jackson" name="jackson-mapper-asl" rev="${jackson.version}" />
+      <exclude org="javax.jms"/>
     <exclude org="com.sun.jdmk"/>
     <exclude org="com.sun.jmx"/>
   </dependencies>

--- a/libraries.properties
+++ b/libraries.properties
@@ -20,3 +20,4 @@ pig.version=0.9.2
 protobuf-java.version=2.3.0
 thrift-test.version=0.5.0
 yamlbeans.version=0.9.3
+jackson.version=1.6.0

--- a/src/java/com/twitter/elephantbird/pig/piggybank/JsonStringToMap.java
+++ b/src/java/com/twitter/elephantbird/pig/piggybank/JsonStringToMap.java
@@ -1,78 +1,77 @@
 package com.twitter.elephantbird.pig.piggybank;
-
-import java.io.IOException;
-import java.util.Map;
-
-import org.apache.log4j.LogManager;
-import org.apache.log4j.Logger;
 import org.apache.pig.EvalFunc;
 import org.apache.pig.backend.executionengine.ExecException;
 import org.apache.pig.data.Tuple;
-import org.apache.pig.impl.logicalLayer.schema.Schema;
-import org.apache.pig.impl.util.Utils;
-import org.apache.pig.parser.ParserException;
-import org.json.simple.JSONObject;
-import org.json.simple.parser.JSONParser;
-import org.json.simple.parser.ParseException;
 
-import com.google.common.collect.Maps;
-import com.twitter.elephantbird.pig.util.PigCounterHelper;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
 
 /**
- * Transforms a Json string into a Pig map whose value type is chararray. Only goes one level deep;
- * All input map values are converted to strings via {@link Object#toString()}.
+ * Delegates to {@link JsonToPigParser} with its defaults (don't create nested maps from nested json, and don't detect
+ * json in all string property values).
+ *
+ * Usage Example:
+ * Given the following json content:
+ * <pre>
+ {"a":1,"message":"{\"b\":2}",detail:{"b":2}}
+ {"a":3,"message":"{\"b\":3}",detail:{"b":2}}
+ {"a":2,"message":"{\"b\":1}",detail:{"b":3}}
+ {"a":9,"message":"{\"b\":22}",detail:{"b":7}}
+ {"a":15,"message":"{\"b\":25}",detail:{"b":9}}
+ {"a":7,"message":"{\"b\":52}",detail:{"b":11}}
+ </pre>
+ * The following pig script will parse out the "a" values from the top level:
+ * <pre>
+ json_strings = LOAD '/test/foo.json' as (json_string);
+ maps = FOREACH json_strings GENERATE com.jivesoftware.pig.JsonToStringMap((chararray)json_string) as json;
+ aVals = foreach maps generate json#'a') as aVal;
+ dump aVals
+ -- Output:
+ (1)
+ (3)
+ (2)
+ (9)
+ (15)
+ (7)
+ </pre>
+ * Getting the EvalFunc to generate nested maps proved to be an exercise in futility (it seems to work just fine from
+ * loaders though:  see {@link com.twitter.elephantbird.pig.util.JsonConverter}.  However, you can get at data under the detail key with:
+ <pre>
+ maps = FOREACH json_strings GENERATE com.jivesoftware.pig.JsonStringToMap((chararray)json_string) as json;
+ details = foreach maps generate com.jivesoftware.pig.JsonStringToMap((chararray)json#'detail') as detail;
+ dump details
+ -- Output:
+ ([b#2])
+ ([b#2])
+ ([b#3])
+ ([b#7])
+ ([b#9])
+ ([b#11])
+ </pre>
  */
-public class JsonStringToMap extends EvalFunc<Map<String, String>> {
-  private static final Logger LOG = LogManager.getLogger(JsonStringToMap.class);
-  private final JSONParser jsonParser = new JSONParser();
-  private final PigCounterHelper counterHelper = new PigCounterHelper();
+public class JsonStringToMap extends EvalFunc<Map> {
+    private final JsonToPigParser parser = JsonToPigParser.DEFAULT;
 
-  @Override
-  public Schema outputSchema(Schema input) {
-    try {
-      return Utils.getSchemaFromString("json: [chararray]");
-    } catch (ParserException e) {
-      throw new RuntimeException(e);
+    @Override
+    public Map exec(Tuple input) throws IOException {
+        try {
+            if (input == null || input.size() < 1) {
+                throw new IOException("Not enough arguments to " + this.getClass().getName() + ": expected at least 1");
+            }
+
+            String json = (String) input.get(0);
+            Map<String, Object> map = parser.toPigMap(json);
+            if(map == null || !parser.isNestedJson()){
+                return map;
+            }
+            Map<String, String> stringMap = new HashMap<String,String>();
+            for(Map.Entry<String,Object> entry : map.entrySet()){
+                stringMap.put(entry.getKey(), String.valueOf(entry.getValue()));
+            }
+            return stringMap;
+        } catch (ExecException e) {
+            throw new IOException(e);
+        }
     }
-  }
-
-  @Override
-  public Map<String, String> exec(Tuple input) throws IOException {
-    try {
-      // Verify the input is valid, logging to a Hadoop counter if not.
-      if (input == null || input.size() < 1) {
-        throw new IOException("Not enough arguments to " + this.getClass().getName() + ": got " + input.size() + ", expected at least 1");
-      }
-
-      if (input.get(0) == null) {
-        counterHelper.incrCounter(getClass().getName(), "NullJsonString", 1L);
-        return null;
-      }
-
-      String jsonLiteral = (String) input.get(0);
-      return parseStringToMap(jsonLiteral);
-    } catch (ExecException e) {
-      LOG.warn("Error in " + getClass() + " with input " + input, e);
-      throw new IOException(e);
-    }
-  }
-
-  protected Map<String, String> parseStringToMap(String line) {
-    try {
-      Map<String, String> values = Maps.newHashMap();
-      JSONObject jsonObj = (JSONObject) jsonParser.parse(line);
-      for (Object key : jsonObj.keySet()) {
-        Object value = jsonObj.get(key);
-        values.put(key.toString(), value != null ? value.toString() : null);
-      }
-      return values;
-    } catch (ParseException e) {
-      LOG.warn("Could not json-decode string: " + line, e);
-      return null;
-    } catch (NumberFormatException e) {
-      LOG.warn("Very big number exceeds the scale of long: " + line, e);
-      return null;
-    }
-  }
-
 }

--- a/src/java/com/twitter/elephantbird/pig/piggybank/JsonToPigParser.java
+++ b/src/java/com/twitter/elephantbird/pig/piggybank/JsonToPigParser.java
@@ -1,0 +1,180 @@
+package com.twitter.elephantbird.pig.piggybank;
+
+import com.twitter.elephantbird.pig.util.PigCounterHelper;
+import org.apache.pig.data.*;
+import org.codehaus.jackson.JsonNode;
+import org.codehaus.jackson.map.ObjectMapper;
+import org.codehaus.jackson.node.ArrayNode;
+import org.codehaus.jackson.node.ObjectNode;
+import org.codehaus.jackson.node.TextNode;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+
+/**
+ * Transforms a Json string into a Pig map.  Supports nested json, but only goes one level deep by default.
+ * When enabled, nested json will be transformed into a nested Pig map structure with the value types being map (for
+ * json objects and maps), bag (for json lists), and charrarray (for everything else).  When
+ * nesting is not enabled, all input map values are converted to Strings via {@link Object#toString()} and the
+ * resulting pig map value type will be charrarray.
+ *
+ * Also supports auto-detecting string values that actually contain a json parsable value within an outer json
+ * structure (disabled by default).  This is convenient for cases where data has already encoded json values as
+ * string fields in an outer data container.  Enabling this feature implies enabling NESTED_JSON support.
+ *
+ * see {@link JsonStringToMap} for example usages.
+ */
+public class JsonToPigParser {
+    private static final Logger LOG = LoggerFactory.getLogger(JsonToPigParser.class);
+    public static final JsonToPigParser DEFAULT = new JsonToPigParser();
+
+    private enum JsonToPigParserCounters {
+        TotalCalls,
+        JsonDecoded,
+        ParseError,
+        NullJsonString,
+        EmbeddedJsonString
+    }
+
+    public enum Features {
+        NESTED_JSON,
+        DETECT_JSON_IN_ALL_STRINGS
+    }
+
+    private static final ObjectMapper mapper = new ObjectMapper();
+    private static final TupleFactory tupleFactory = TupleFactory.getInstance();
+    private static final BagFactory bagFactory = DefaultBagFactory.getInstance();
+
+    private final PigCounterHelper counterHelper = new PigCounterHelper();
+
+    private boolean detectJsonInAllStrings;
+    private boolean nestedJson;
+
+    public JsonToPigParser() {
+        this((Features[])null);
+    }
+
+    public JsonToPigParser(String... features){
+        this(parseFeatures(features));
+    }
+
+    public JsonToPigParser(Features...features){
+        if(features != null){
+            for(Features feature : features){
+                switch(feature){
+                    case DETECT_JSON_IN_ALL_STRINGS:
+                        detectJsonInAllStrings = true;
+                        break;
+                    case NESTED_JSON:
+                        nestedJson = true;
+                        break;
+                }
+            }
+        }
+        if(this.detectJsonInAllStrings && !this.nestedJson){
+            LOG.warn("The NESTED_JSON feature must be enabled when DETECT_JSON_IN_ALL_STRINGS is enabled.");
+            this.nestedJson = true;
+        }
+    }
+
+    public Map<String,Object> toPigMap(String json){
+        counterHelper.incrCounter(JsonToPigParserCounters.TotalCalls, 1);
+        if(json == null || "null".equals(json)){
+            counterHelper.incrCounter(JsonToPigParserCounters.NullJsonString, 1);
+            return null;
+        }
+        try {
+            JsonNode jsonNode = mapper.readTree(json);
+            counterHelper.incrCounter(JsonToPigParserCounters.JsonDecoded, 1);
+            if(jsonNode instanceof TextNode){
+                try{
+                    jsonNode = mapper.readTree(jsonNode.getTextValue());
+                }catch(Exception ex){
+                    //node doesn't contain json, just return the string as normal
+                }
+            }
+
+            if(jsonNode instanceof ObjectNode){
+                return walkJson((ObjectNode) jsonNode);
+            }
+
+            Map<String,Object> v = new HashMap<String, Object>();
+            Object value;
+            if(jsonNode instanceof ArrayNode){
+                value = walkJson((ArrayNode)jsonNode);
+            }else{
+                value = wrap(jsonNode);
+            }
+            v.put("value", value);
+            return v;
+        }catch(Exception ex){
+            LOG.warn("Could not json-decode string: {}, {}", new Object[]{json, ex.getMessage(), ex});
+            counterHelper.incrCounter(JsonToPigParserCounters.ParseError, 1);
+            return null;
+        }
+    }
+
+    public boolean isNestedJson() {
+        return nestedJson;
+    }
+
+    public boolean isDetectJsonInAllStrings() {
+        return detectJsonInAllStrings;
+    }
+
+    protected Map<String,Object> walkJson(ObjectNode jsonObj) {
+        Map<String,Object> v = new HashMap<String, Object>();
+        Iterator<Map.Entry<String,JsonNode>> fields = jsonObj.getFields();
+        while(fields.hasNext()){
+            Map.Entry<String, JsonNode> field = fields.next();
+            v.put(field.getKey(), wrap(field.getValue()));
+        }
+        return v;
+    }
+
+    protected Object walkJson(ArrayNode value) {
+        DataBag mapValue = bagFactory.newDefaultBag();
+        for (int i=0; i<value.size(); i++) {
+            Tuple t = tupleFactory.newTuple(wrap(value.get(i)));
+            mapValue.add(t);
+        }
+        return mapValue;
+    }
+
+    protected Object wrap(JsonNode value) {
+        if(value == null || value.isNull()){
+            return null;
+        }
+        if(nestedJson){
+            if (value instanceof ObjectNode) {
+                return walkJson((ObjectNode) value);
+            } else if (value instanceof ArrayNode) {
+                return walkJson((ArrayNode) value);
+            }else if (detectJsonInAllStrings && value instanceof TextNode){
+                try{
+                    //attempt to parse the json to 'detect' json embedded string values
+                    Object wrapped = wrap(mapper.readTree(value.getTextValue()));
+                    counterHelper.incrCounter(JsonToPigParserCounters.EmbeddedJsonString, 1);
+                    return wrapped;
+                }catch(Exception ex){
+                    //totally fine, the string value doesn't contain json, it's just a string
+                }
+            }
+        }
+        if(value instanceof TextNode){
+            return value.getValueAsText();
+        }
+        return value.toString();
+    }
+
+    private static Features[] parseFeatures(String[] featureStrs) {
+        Features[] features = new Features[featureStrs.length];
+        for(int i=0;i<features.length;i++){
+            features[i] = Features.valueOf(featureStrs[i].toUpperCase());
+        }
+        return features;
+    }
+}

--- a/src/java/com/twitter/elephantbird/pig/util/JsonConverter.java
+++ b/src/java/com/twitter/elephantbird/pig/util/JsonConverter.java
@@ -1,0 +1,133 @@
+package com.twitter.elephantbird.pig.util;
+
+import com.twitter.elephantbird.pig.piggybank.JsonToPigParser;
+import org.apache.pig.ResourceSchema;
+import org.apache.pig.data.*;
+
+import java.io.IOException;
+
+/**
+ * Converter for use by the {@link com.twitter.elephantbird.pig.load.SequenceFileLoader}.
+ * Delegates to {@link JsonToPigParser} with its defaults (don't create nested maps from nested json, and don't detect
+ * json in all string property values).
+ *
+ * Usage Example:
+ * Given a sequence file at /test/foo.seq with Null keys, and Text (json) values similar to:
+ * <pre>
+ <null> {"a":1,"message":"{\"b\":2}",detail:{"b":2}}
+ <null> {"a":3,"message":"{\"b\":3}",detail:{"b":2}}
+ <null> {"a":2,"message":"{\"b\":1}",detail:{"b":3}}
+ <null> {"a":9,"message":"{\"b\":22}",detail:{"b":7}}
+ <null> {"a":15,"message":"{\"b\":25}",detail:{"b":9}}
+ <null> {"a":7,"message":"{\"b\":52}",detail:{"b":11}}
+ </pre>
+ * The following pig script will parse out the "a" values from the top level:
+ * <pre>
+ json_maps = LOAD '/test/foo.seq' USING com.twitter.elephantbird.pig.load.SequenceFileLoader (
+ '-c com.twitter.elephantbird.pig.util.NullWritableConverter',
+ '-c com.jivesoftware.pig.JsonConverter')
+ AS (key, json_map);
+ aVals = FOREACH json_maps GENERATE json_map#'a' as aVal;
+ dump aVals
+ -- Output:
+ (1)
+ (3)
+ (2)
+ (9)
+ (15)
+ (7)
+
+ * By default nesting is not enabled, so all child properties will just be the string values:
+
+ detailStrings = FOREACH json_maps GENERATE json_map#'detail';
+ dump detailStrings;
+ -- Output:
+ ({"b":2})
+ ({"b":2})
+ ({"b":3})
+ ({"b":7})
+ ({"b":9})
+ ({"b":11})
+
+ * Enable nested support with the NESTED_JSON argument to the converter:
+ json_maps = LOAD '/test/foo.seq' USING com.twitter.elephantbird.pig.load.SequenceFileLoader (
+ '-c com.twitter.elephantbird.pig.util.NullWritableConverter',
+ '-c com.jivesoftware.pig.JsonConverter NESTED_JSON')
+ AS (key, json_map);
+ details = FOREACH json_maps GENERATE json_map#'detail';
+ dump details;
+ -- Output:
+ [b#2]
+ [b#2]
+ [b#3]
+ [b#7]
+ [b#9]
+ [b#11]
+
+ * Also, by default, if the json map contains string values that are actually more json encoded data, the converter
+ * will not detect that (even with NESTED_JSON enabled):
+ json_maps = LOAD '/test/foo.seq' USING com.twitter.elephantbird.pig.load.SequenceFileLoader (
+ '-c com.twitter.elephantbird.pig.util.NullWritableConverter',
+ '-c com.jivesoftware.pig.JsonConverter NESTED_JSON')
+ AS (key, json_map);
+ messages = FOREACH json_maps GENERATE json_map#'message';
+ dump messages;
+ -- Output:
+ {"b":2}
+ {"b":3}
+ {"b":1}
+ {"b":22}
+ {"b":25}
+ {"b":52}
+
+ * Enable the auto-detection of string values that are themselves json with the DETECT_JSON_IN_ALL_STRINGS argument
+ * to the converter:
+
+ json_maps = LOAD '/test/foo.seq' USING com.twitter.elephantbird.pig.load.SequenceFileLoader (
+ '-c com.twitter.elephantbird.pig.util.NullWritableConverter',
+ '-c com.jivesoftware.pig.JsonConverter DETECT_JSON_IN_ALL_STRINGS')
+ AS (key, json_map);
+ messages = FOREACH json_maps GENERATE json_map#'message';
+ dump messages;
+ -- Output:
+ [b#2]
+ [b#3]
+ [b#1]
+ [b#22]
+ [b#25]
+ [b#52]
+ </pre>
+ */
+public class JsonConverter extends TextConverter {
+    private final JsonToPigParser parser;
+
+    public JsonConverter() {
+        this(new JsonToPigParser());
+    }
+
+    public JsonConverter(String...features){
+        this(new JsonToPigParser(features));
+    }
+
+    public JsonConverter(JsonToPigParser.Features...features){
+        this(new JsonToPigParser(features));
+    }
+
+    public JsonConverter(JsonToPigParser parser) {
+        this.parser = parser;
+    }
+
+    @Override
+    public ResourceSchema.ResourceFieldSchema getLoadSchema() throws IOException {
+        ResourceSchema.ResourceFieldSchema schema = new ResourceSchema.ResourceFieldSchema();
+        schema.setType(DataType.MAP);
+        return schema;
+    }
+
+
+    @Override
+    public Object bytesToObject(DataByteArray dataByteArray) throws IOException {
+        String json = (String) super.bytesToObject(dataByteArray);
+        return parser.toPigMap(json);
+    }
+}

--- a/src/test/com/twitter/elephantbird/pig/piggybank/TestJsonToPigParser.java
+++ b/src/test/com/twitter/elephantbird/pig/piggybank/TestJsonToPigParser.java
@@ -1,0 +1,210 @@
+package com.twitter.elephantbird.pig.piggybank;
+import org.apache.pig.backend.executionengine.ExecException;
+import org.apache.pig.data.DataBag;
+import org.apache.pig.data.Tuple;
+import org.codehaus.jackson.map.ObjectMapper;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.*;
+
+import static com.twitter.elephantbird.pig.piggybank.JsonToPigParser.Features.DETECT_JSON_IN_ALL_STRINGS;
+import static com.twitter.elephantbird.pig.piggybank.JsonToPigParser.Features.NESTED_JSON;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+public class TestJsonToPigParser {
+    private static final ObjectMapper mapper = new ObjectMapper();
+    private Person john;
+    private String johnJsonString;
+
+    @Before
+    public void setup() throws IOException {
+        john = new Person("john");
+
+        Person jane = new Person("jane");
+        john.setSpouse(jane);
+        Map details = new HashMap();
+        details.put("age", 29);
+        details.put("likes", Arrays.asList("the letter 'J'", "cookies"));
+        jane.setDetailsString(mapper.writeValueAsString(details));
+        jane.setDetails(details);
+
+        Person jimmy = new Person("jimmy");
+        Person jenny = new Person("jenny");
+
+        john.addChildren(jimmy, jenny);
+        johnJsonString = mapper.writeValueAsString(john);
+    }
+
+    @Test
+    public void returnNullForInvalidJson(){
+        JsonToPigParser parser = new JsonToPigParser();
+        assertNull(parser.toPigMap("..."));
+    }
+
+    @Test
+    public void wrapNonObjectsIntoMap() throws ExecException {
+        JsonToPigParser parser = new JsonToPigParser();
+        Map map = parser.toPigMap("100");
+        assertEquals("100",map.get("value"));
+
+        map = parser.toPigMap("\"a\"");
+        assertEquals("a", map.get("value"));
+
+        map = parser.toPigMap("[\"a\"]");
+        DataBag bag = (DataBag)map.get("value");
+        Tuple tuple = bag.iterator().next();
+        assertEquals("a", tuple.get(0));
+    }
+
+    @Test
+    public void supportWrappedJsonString(){
+        JsonToPigParser parser = new JsonToPigParser();
+        String doubleJson = "\"{\\\"a\\\":22}\"";
+        Map map = parser.toPigMap(doubleJson);
+        assertEquals("22", map.get("a"));
+    }
+
+    @Test
+    public void convertSimpleTopLevelFields(){
+        JsonToPigParser nestedConverter = new JsonToPigParser();
+        Map<String,Object> pigJohn = nestedConverter.toPigMap(johnJsonString);
+        assertSimpleFieldsMatch(john, pigJohn);
+    }
+
+    @Test
+    public void convertNestedMaps() throws ExecException {
+        JsonToPigParser nestedConverter = new JsonToPigParser(NESTED_JSON);
+        Map<String,Object> pigJohn = nestedConverter.toPigMap(johnJsonString);
+
+        Person spouse = john.getSpouse();
+        Map spouseMap = (Map)pigJohn.get("spouse");
+        assertSimpleFieldsMatch(spouse, spouseMap);
+    }
+
+    @Test
+    public void convertMultiLevelNesting() throws ExecException {
+        JsonToPigParser nestedConverter = new JsonToPigParser(NESTED_JSON);
+        Map<String,Object> pigJohn = nestedConverter.toPigMap(johnJsonString);
+
+        Person spouse = john.getSpouse();
+        Map spouseMap = (Map)pigJohn.get("spouse");
+
+        Map<String,Object> detailsMap = (Map<String,Object>)spouseMap.get("details");
+        assertEquals(String.valueOf(spouse.getDetails().get("age")), detailsMap.get("age"));
+
+        DataBag likesBag = (DataBag)detailsMap.get("likes");
+        List expectedLikesList = (List)spouse.getDetails().get("likes");
+        assertEquals(expectedLikesList.size(), likesBag.size());
+
+        Iterator likesBagIter = likesBag.iterator();
+        int i=0;
+        while(likesBagIter.hasNext()){
+            Tuple likeTuple = (Tuple)likesBagIter.next();
+            assertEquals(expectedLikesList.get(i++), likeTuple.get(0));
+        }
+
+        DataBag childrenBag = (DataBag)pigJohn.get("children");
+        List<Person> expectedChildrenList = john.getChildren();
+        assertEquals(expectedChildrenList.size(), childrenBag.size());
+
+        Iterator childrenBagIter = childrenBag.iterator();
+        i=0;
+        while(childrenBagIter.hasNext()){
+            Tuple childTuple = (Tuple)childrenBagIter.next();
+            assertSimpleFieldsMatch(expectedChildrenList.get(i++), (Map) childTuple.get(0));
+        }
+
+    }
+
+    @Test
+    public void supportFlatteningNestedJsonStructures() throws IOException {
+        JsonToPigParser flatteningConverter = new JsonToPigParser();
+        Map<String,Object> pigJohn = flatteningConverter.toPigMap(johnJsonString);
+        assertSimpleFieldsMatch(john, pigJohn);
+        assertEquals(mapper.writeValueAsString(john.getSpouse()), pigJohn.get("spouse"));
+        assertEquals(mapper.writeValueAsString(john.getChildren()), pigJohn.get("children"));
+    }
+
+    @Test
+    public void supportDetectingEmbeddedJsonInStringFieldValues(){
+        JsonToPigParser parserWithEmbedDetection = new JsonToPigParser(DETECT_JSON_IN_ALL_STRINGS);
+        Map<String,Object> pigJohn = parserWithEmbedDetection.toPigMap(johnJsonString);
+        assertSimpleFieldsMatch(john, pigJohn);
+        Map spouseMap = (Map)pigJohn.get("spouse");
+        Map spouseDetailsString = (Map)spouseMap.get("detailsString");
+        Map spouseDetails = (Map)spouseMap.get("details");
+        assertEquals(spouseDetails, spouseDetailsString);
+    }
+
+    @Test
+    public void parseNullStringAsNull(){
+        JsonToPigParser parser = new JsonToPigParser();
+        assertNull(parser.toPigMap("null"));
+    }
+
+    private void assertSimpleFieldsMatch(Person person, Map pigMap) {
+        assertEquals(String.valueOf(person.getId()), pigMap.get("id"));
+        assertEquals(person.getName(), pigMap.get("name"));
+        assertEquals(person.getDetailsString(), pigMap.get("detailsString"));
+    }
+}
+
+class Person{
+    private static int nextId = 1;
+
+    private int id;
+    private String name;
+    private List<Person> children;
+    private Person spouse;
+    private Map details;
+    private String detailsString;
+
+    Person(String name){
+        id = nextId++;
+        this.name = name;
+        children = new ArrayList<Person>();
+    }
+
+    void addChildren(Person...children){
+        this.children.addAll(Arrays.asList(children));
+    }
+
+    void setSpouse(Person spouse){
+        this.spouse = spouse;
+    }
+
+    public void setDetails(Map details) {
+        this.details = details;
+    }
+
+    public void setDetailsString(String infoString) {
+        this.detailsString = infoString;
+    }
+
+    public int getId() {
+        return id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public List<Person> getChildren() {
+        return children;
+    }
+
+    public Person getSpouse() {
+        return spouse;
+    }
+
+    public Map getDetails() {
+        return details;
+    }
+
+    public String getDetailsString() {
+        return detailsString;
+    }
+}


### PR DESCRIPTION
These commits started with a need to have a JsonConverter with nesting support to be used by the SequenceFileLoader.  There are several places in elephant-bird that do json work, and they seem to do it differently.  It seems reasonable to start to refactor those places to delegate to a single json parsing utility.  

So, the first commit simply adds JsonToPigParser, which is mostly the same code as what is in JsonLoader, but uses the jackson json parser instead of simple-json.  It supports creating nested maps from nested json, as well as detecting string values that have json data (think avro json structures that have a field that is essentially a json payload).  Has tests.

The next commit adds the JsonConverter for use with the SequenceFileLoader.  The javadoc shows usage.

The final commit modifies the JsonStringToMap to delegate to the JsonToPigParser.  I REALLY wish I could get the nesting to work here.  It was easy enough to add, but pig refused to allow me to refer to the nested structures.  What is strange is that the nesting support DOES work in the JsonConverter scenario.

Next steps might be to refactor the existing Json\* classes to delegate to the JsonToPigParser.
