### PR TITLE
Removes m2e filtering of build-helper-maven-plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -480,19 +480,6 @@
                     <ignore />
                   </action>
                 </pluginExecution>
-                <pluginExecution>
-                  <pluginExecutionFilter>
-                    <groupId>org.codehaus.mojo</groupId>
-                    <artifactId>build-helper-maven-plugin</artifactId>
-                    <versionRange>[0.0.1,)</versionRange>
-                    <goals>
-                      <goal>add-source</goal>
-                    </goals>
-                  </pluginExecutionFilter>
-                  <action>
-                    <ignore />
-                  </action>
-                </pluginExecution>
               </pluginExecutions>
             </lifecycleMappingMetadata>
           </configuration>


### PR DESCRIPTION
There is now an Eclipse M2E "connector" which supports this plugin, so I've removed this bit of config so Eclipse M2E users can take advantage of it.

When enabled, M2E will automatically add paths containing generated protobuf / thrift source code to build path configuration. Sweetness.
