### PR TITLE
Update build so LZO tests work correctly

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -338,7 +338,7 @@
           </dependencies>
           <configuration>
             <redirectTestOutputToFile>true</redirectTestOutputToFile>
-	    <argLine>-Djava.library.path=${test.library.path}</argLine>
+            <argLine>-Djava.library.path=${test.library.path}</argLine>
           </configuration>
         </plugin>
 


### PR DESCRIPTION
Bump hadoop-lzo dependency and add a build flag so LZO tests run correctly. How to release doc has already been updated.
