### PR TITLE
avoid repeating dependencies in sub modules

### DIFF
--- a/cascading2/pom.xml
+++ b/cascading2/pom.xml
@@ -25,14 +25,6 @@
       <artifactId>elephant-bird-core</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-log4j12</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>com.google.protobuf</groupId>
-      <artifactId>protobuf-java</artifactId>
-    </dependency>
-    <dependency>
       <groupId>cascading</groupId>
       <artifactId>cascading-hadoop</artifactId>
     </dependency>

--- a/hive/pom.xml
+++ b/hive/pom.xml
@@ -33,10 +33,6 @@
       <artifactId>elephant-bird-core</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-log4j12</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.apache.hive</groupId>
       <artifactId>hive-serde</artifactId>
     </dependency>

--- a/mahout/pom.xml
+++ b/mahout/pom.xml
@@ -23,10 +23,6 @@
       <type>test-jar</type>
     </dependency>
     <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-log4j12</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.apache.mahout</groupId>
       <artifactId>mahout-collections</artifactId>
     </dependency>

--- a/pig/pom.xml
+++ b/pig/pom.xml
@@ -18,10 +18,6 @@
       <artifactId>elephant-bird-core</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-log4j12</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.antlr</groupId>
       <artifactId>antlr</artifactId>
     </dependency>

--- a/rcfile/pom.xml
+++ b/rcfile/pom.xml
@@ -21,9 +21,5 @@
       <groupId>com.twitter.elephantbird</groupId>
       <artifactId>elephant-bird-hive</artifactId>
     </dependency>
-    <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-log4j12</artifactId>
-    </dependency>
   </dependencies>
 </project>


### PR DESCRIPTION
slf4j-log4j12 dependency was repeated in sub modules as well. It is unnecessary.
