### PR TITLE
Stop using DefaultDataBags, use NonSpillable ones instead.

### DIFF
--- a/pig/src/main/java/com/twitter/elephantbird/pig/load/JsonLoader.java
+++ b/pig/src/main/java/com/twitter/elephantbird/pig/load/JsonLoader.java
@@ -13,9 +13,8 @@ import org.apache.hadoop.mapreduce.lib.input.FileInputFormat;
 import org.apache.hadoop.mapreduce.lib.input.TextInputFormat;
 import org.apache.pig.PigException;
 import org.apache.pig.backend.executionengine.ExecException;
-import org.apache.pig.data.BagFactory;
 import org.apache.pig.data.DataBag;
-import org.apache.pig.data.DefaultBagFactory;
+import org.apache.pig.data.NonSpillableDataBag;
 import org.apache.pig.data.Tuple;
 import org.apache.pig.data.TupleFactory;
 import org.apache.pig.impl.PigContext;
@@ -45,7 +44,6 @@ import java.util.Map;
 public class JsonLoader extends LzoBaseLoadFunc {
   private static final Logger LOG = LoggerFactory.getLogger(JsonLoader.class);
   private static final TupleFactory tupleFactory = TupleFactory.getInstance();
-  private static final BagFactory bagFactory = DefaultBagFactory.getInstance();
   
   public static final String NESTED_LOAD_KEY = "elephantbird.jsonloader.nestedLoad";
   
@@ -190,7 +188,7 @@ public class JsonLoader extends LzoBaseLoadFunc {
     }  else if (isNestedLoadEnabled && value instanceof JSONArray) {
       
       JSONArray a = (JSONArray) value;
-      DataBag mapValue = bagFactory.newDefaultBag();
+      DataBag mapValue = new NonSpillableDataBag(a.size());
       for (int i=0; i<a.size(); i++) {
         Tuple t = tupleFactory.newTuple(wrap(a.get(i)));
         mapValue.add(t);

--- a/pig/src/main/java/com/twitter/elephantbird/pig/util/ThriftToPig.java
+++ b/pig/src/main/java/com/twitter/elephantbird/pig/util/ThriftToPig.java
@@ -10,10 +10,10 @@ import java.util.Map.Entry;
 
 import org.apache.pig.LoadFunc;
 import org.apache.pig.backend.executionengine.ExecException;
-import org.apache.pig.data.BagFactory;
 import org.apache.pig.data.DataBag;
 import org.apache.pig.data.DataByteArray;
 import org.apache.pig.data.DataType;
+import org.apache.pig.data.NonSpillableDataBag;
 import org.apache.pig.data.Tuple;
 import org.apache.pig.data.TupleFactory;
 import org.apache.pig.impl.logicalLayer.FrontendException;
@@ -39,7 +39,6 @@ public class ThriftToPig<M extends TBase<?, ?>> {
 
   public static final Logger LOG = LoggerFactory.getLogger(ThriftToPig.class);
 
-  private static BagFactory bagFactory = BagFactory.getInstance();
   private static TupleFactory tupleFactory  = TupleFactory.getInstance();
 
   private TStructDescriptor structDesc;
@@ -188,7 +187,7 @@ public class ThriftToPig<M extends TBase<?, ?>> {
         tuples.add(tupleFactory.newTuple(pValue));
       }
     }
-    return bagFactory.newDefaultBag(tuples);
+    return new NonSpillableDataBag(tuples);
   }
 
   @SuppressWarnings("serial")

--- a/pig/src/test/java/com/twitter/elephantbird/pig/piggybank/Fixtures.java
+++ b/pig/src/test/java/com/twitter/elephantbird/pig/piggybank/Fixtures.java
@@ -1,10 +1,12 @@
 package com.twitter.elephantbird.pig.piggybank;
 
 import org.apache.pig.backend.executionengine.ExecException;
-import org.apache.pig.data.BagFactory;
 import org.apache.pig.data.DataBag;
+import org.apache.pig.data.NonSpillableDataBag;
 import org.apache.pig.data.Tuple;
 import org.apache.pig.data.TupleFactory;
+
+import com.google.common.collect.Lists;
 
 import com.twitter.data.proto.tutorial.AddressBookProtos.AddressBook;
 import com.twitter.data.proto.tutorial.AddressBookProtos.Person;
@@ -14,7 +16,6 @@ import com.twitter.data.proto.tutorial.AddressBookProtos.Person.PhoneType;
 public class Fixtures {
 
   public static TupleFactory tf_ = TupleFactory.getInstance();
-  public static BagFactory bf_ = BagFactory.getInstance();
 
   public static AddressBook buildAddressBookProto() {
     AddressBook abProto = AddressBook.newBuilder()
@@ -36,10 +37,10 @@ public class Fixtures {
   }
   
   public static Tuple buildPersonTuple() throws ExecException {
-    DataBag phoneBag = bf_.newDefaultBag();
-    phoneBag.add(makePhoneNumberTuple("415-999-9999", null));
-    phoneBag.add(makePhoneNumberTuple("415-666-6666", "MOBILE"));
-    phoneBag.add(makePhoneNumberTuple("415-333-3333", "WORK"));
+    DataBag phoneBag = new NonSpillableDataBag(
+      Lists.newArrayList(makePhoneNumberTuple("415-999-9999", null), 
+      makePhoneNumberTuple("415-666-6666", "MOBILE"),
+      makePhoneNumberTuple("415-333-3333", "WORK")));
     
     Tuple entryTuple = tf_.newTuple(4);
     entryTuple.set(0, "Elephant Bird");
@@ -50,9 +51,9 @@ public class Fixtures {
   }
   // {(Elephant Bird,123,elephant@bird.com,{(415-999-9999,HOME),(415-666-6666,MOBILE),(415-333-3333,WORK)})}
   public static Tuple buildAddressBookTuple() throws ExecException {
-    DataBag entryBag = bf_.newDefaultBag();
-    entryBag.add(buildPersonTuple());
-    entryBag.add(buildPersonTuple());
+    DataBag entryBag = new NonSpillableDataBag(
+     Lists.newArrayList(buildPersonTuple(),
+     buildPersonTuple()));
     return tf_.newTuple(entryBag);
   }
 

--- a/pig/src/test/java/com/twitter/elephantbird/pig/piggybank/TestInvoker.java
+++ b/pig/src/test/java/com/twitter/elephantbird/pig/piggybank/TestInvoker.java
@@ -24,8 +24,8 @@ import static org.junit.Assert.assertTrue;
 import java.io.IOException;
 
 import org.apache.pig.EvalFunc;
-import org.apache.pig.data.BagFactory;
 import org.apache.pig.data.DataBag;
+import org.apache.pig.data.NonSpillableDataBag;
 import org.apache.pig.data.Tuple;
 import org.apache.pig.data.TupleFactory;
 import org.apache.pig.impl.logicalLayer.FrontendException;
@@ -44,7 +44,6 @@ import com.twitter.elephantbird.pig.piggybank.InvokeForString;
 public class TestInvoker {
 
     private final TupleFactory tf_ = TupleFactory.getInstance();
-    private final BagFactory bf_ = BagFactory.getInstance();
 
     @Test
     public void testStringInvoker() throws SecurityException, ClassNotFoundException, NoSuchMethodException, IOException {
@@ -149,7 +148,7 @@ public class TestInvoker {
     }
 
     private DataBag newSimpleBag(Object... objects) {
-      DataBag bag = bf_.newDefaultBag();
+      DataBag bag = new NonSpillableDataBag(objects.length);
       for (Object o : objects) {
         bag.add(tf_.newTuple(o));
       }

--- a/pig/src/test/java/com/twitter/elephantbird/pig/util/TestPigToProtobuf.java
+++ b/pig/src/test/java/com/twitter/elephantbird/pig/util/TestPigToProtobuf.java
@@ -8,8 +8,8 @@ import com.twitter.data.proto.tutorial.AddressBookProtos.Person.PhoneNumber;
 import com.twitter.data.proto.tutorial.AddressBookProtos.Person.PhoneType;
 
 import org.apache.pig.ResourceSchema;
-import org.apache.pig.data.BagFactory;
 import org.apache.pig.data.DataType;
+import org.apache.pig.data.NonSpillableDataBag;
 import org.apache.pig.data.Tuple;
 import org.apache.pig.data.TupleFactory;
 import org.apache.pig.impl.logicalLayer.schema.Schema;
@@ -122,9 +122,8 @@ public class TestPigToProtobuf {
   private static Tuple personTuple(String name, int id, String email, String phoneNumber,
       String phoneType) {
     TupleFactory tf = TupleFactory.getInstance();
-    BagFactory bf = BagFactory.getInstance();
     return tf.newTupleNoCopy(Lists.<Object> newArrayList(name, id, email,
-        bf.newDefaultBag(Lists.newArrayList(tf.newTupleNoCopy(Lists.<Object> newArrayList(
+        new NonSpillableDataBag(Lists.newArrayList(tf.newTupleNoCopy(Lists.<Object> newArrayList(
             phoneNumber, phoneType))))));
   }
 

--- a/pig/src/test/java/com/twitter/elephantbird/pig/util/TestPigToThrift.java
+++ b/pig/src/test/java/com/twitter/elephantbird/pig/util/TestPigToThrift.java
@@ -1,6 +1,6 @@
 package com.twitter.elephantbird.pig.util;
 
-import org.apache.pig.data.BagFactory;
+import org.apache.pig.data.NonSpillableDataBag;
 import org.apache.pig.data.Tuple;
 import org.apache.pig.data.TupleFactory;
 import org.junit.Assert;
@@ -27,10 +27,9 @@ public class TestPigToThrift {
   private static Tuple personTuple(String name, int id, String email, String phoneNumber,
       String phoneType) {
     TupleFactory tf = TupleFactory.getInstance();
-    BagFactory bf = BagFactory.getInstance();
     return tf.newTupleNoCopy(Lists.<Object> newArrayList(
         tf.newTupleNoCopy(Lists.<Object> newArrayList(name, null)), id, email,
-        bf.newDefaultBag(Lists.newArrayList(tf.newTupleNoCopy(Lists.<Object> newArrayList(
+        new NonSpillableDataBag(Lists.newArrayList(tf.newTupleNoCopy(Lists.<Object> newArrayList(
             phoneNumber, phoneType))))));
   }
 


### PR DESCRIPTION
DefaultDataBags create WeakReferences in SpillableMemoryManager, which costs 32 bytes (!) per instance, and are poorly GC'd. It doesn't make sense to pay that overhead for bags we know to be small.

I ran a simple benchmark looking at memory utilization of ToBag(), which had the same problem, and saw that 60K strings being inserted into bags created 500KB overhead in DefaultDataBag objects (not counting the strings themselves), and another 2MB in WeakReferences. Switching to NonSpillableDataBag dropped overhead to 175KB.
