### PR TITLE
add 'examples' to dependencyManagement section.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -137,6 +137,11 @@
         <artifactId>elephant-bird-rcfile</artifactId>
         <version>${project.version}</version>
       </dependency>
+      <dependency>
+        <groupId>${project.groupId}</groupId>
+        <artifactId>elephant-bird-example</artifactId>
+        <version>${project.version}</version>
+      </dependency>
 
       <!-- testing -->
       <dependency>


### PR DESCRIPTION
This was a left over from previous pull #248. I didn't notice Andy had already pulled it. 
