### PR TITLE
RCFile Protobuf/Thrift inputformats should rerturn Protbuf/Thrif Writables

### DIFF
--- a/rcfile/src/main/java/com/twitter/elephantbird/pig/load/RCFileProtobufPigLoader.java
+++ b/rcfile/src/main/java/com/twitter/elephantbird/pig/load/RCFileProtobufPigLoader.java
@@ -32,20 +32,6 @@ public class RCFileProtobufPigLoader extends ProtobufPigLoader<Message> {
     return new RCFileProtobufInputFormat(typeRef);
   }
 
-  @SuppressWarnings("unchecked")
-  protected <M> M getNextBinaryValue(TypeRef<M> typeRef) throws IOException {
-    try {
-      if (protoReader.nextKeyValue()) {
-        return (M) protoReader.getCurrentProtobufValue();
-      }
-    } catch (InterruptedException e) {
-      throw new IOException(e);
-    }
-
-    return null;
-  }
-
-
   @Override
   public Tuple getNext() throws IOException {
     if (protoReader.isReadingUnknonwsColumn()) {
@@ -67,8 +53,7 @@ public class RCFileProtobufPigLoader extends ProtobufPigLoader<Message> {
 
   @Override @SuppressWarnings("unchecked")
   public void prepareToRead(RecordReader reader, PigSplit split) {
-    // pass null so that, there is no way it could be misused
-    super.prepareToRead(null, split);
+    super.prepareToRead(reader, split);
     protoReader = (RCFileProtobufInputFormat.ProtobufReader) reader;
   }
 

--- a/rcfile/src/main/java/com/twitter/elephantbird/pig/load/RCFileThriftPigLoader.java
+++ b/rcfile/src/main/java/com/twitter/elephantbird/pig/load/RCFileThriftPigLoader.java
@@ -33,21 +33,6 @@ public class RCFileThriftPigLoader extends ThriftPigLoader<TBase<?,?>> {
     return new RCFileThriftInputFormat(typeRef);
   }
 
-  @SuppressWarnings("unchecked")
-  protected <M> M getNextBinaryValue(TypeRef<M> typeRef) throws IOException {
-    try {
-      if (thriftReader.nextKeyValue()) {
-        return (M) thriftReader.getCurrentThriftValue();
-      }
-    } catch (TException e) {
-      throw new IOException(e);
-    } catch (InterruptedException e) {
-      throw new IOException(e);
-    }
-
-    return null;
-  }
-
   @Override
   public Tuple getNext() throws IOException {
     if (thriftReader.isReadingUnknonwsColumn()) {
@@ -71,8 +56,7 @@ public class RCFileThriftPigLoader extends ThriftPigLoader<TBase<?,?>> {
 
   @Override @SuppressWarnings("unchecked")
   public void prepareToRead(RecordReader reader, PigSplit split) {
-    // pass null so that, there is no way it could be misused
-    super.prepareToRead(null, split);
+    super.prepareToRead(reader, split);
     thriftReader = (RCFileThriftInputFormat.ThriftReader) reader;
   }
 


### PR DESCRIPTION
RCFile Protobuf/Thrift inputformats should rerturn Protbuf/Thrif Writables 

earlier these returned ByteRefArrayWritable, which is not perticularly useful.
it might not be feasible for users to cast the record reader to
invoke getCurrentProtbufValue() or getCurrentThriftValue() directly.

This is also required for cascading/scalding.
