### PR TITLE
Rcfile proto thrift writables

### DIFF
--- a/rcfile/src/main/java/com/twitter/elephantbird/mapreduce/input/RCFileBaseInputFormat.java
+++ b/rcfile/src/main/java/com/twitter/elephantbird/mapreduce/input/RCFileBaseInputFormat.java
@@ -1,0 +1,34 @@
+package com.twitter.elephantbird.mapreduce.input;
+
+import org.apache.hadoop.hive.ql.io.RCFileInputFormat;
+import org.apache.hadoop.io.LongWritable;
+import org.apache.hadoop.io.Writable;
+import org.apache.hadoop.mapreduce.InputSplit;
+import org.apache.hadoop.mapreduce.RecordReader;
+import org.apache.hadoop.mapreduce.TaskAttemptContext;
+
+import java.io.IOException;
+
+/**
+ * Base input format for Thrift and Protobuf RCFile input formats. <br>
+ * contains a few common common utility methods.
+ */
+public abstract class RCFileBaseInputFormat extends MapReduceInputFormatWrapper<LongWritable, Writable> {
+
+  /** internal, for MR use only. */
+  @SuppressWarnings({ "unchecked", "rawtypes" })
+  public RCFileBaseInputFormat() {
+    super(new RCFileInputFormat());
+  }
+
+  /**
+   * returns super.createRecordReader(split, taskAttempt). This is useful when
+   * a sub class has its own their own wrapper over the base recordreader.
+   */
+  protected final RecordReader<LongWritable, Writable>
+  createUnwrappedRecordReader(InputSplit split, TaskAttemptContext taskAttempt)
+          throws IOException, InterruptedException {
+    return super.createRecordReader(split, taskAttempt);
+  }
+
+}

--- a/rcfile/src/main/java/com/twitter/elephantbird/mapreduce/input/RCFileProtobufInputFormat.java
+++ b/rcfile/src/main/java/com/twitter/elephantbird/mapreduce/input/RCFileProtobufInputFormat.java
@@ -7,7 +7,6 @@ import java.util.List;
 import com.twitter.elephantbird.mapreduce.io.ProtobufWritable;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
-import org.apache.hadoop.hive.ql.io.RCFileInputFormat;
 import org.apache.hadoop.hive.serde2.ColumnProjectionUtils;
 import org.apache.hadoop.hive.serde2.columnar.BytesRefArrayWritable;
 import org.apache.hadoop.hive.serde2.columnar.BytesRefWritable;
@@ -18,8 +17,6 @@ import org.apache.hadoop.mapreduce.RecordReader;
 import org.apache.hadoop.mapreduce.TaskAttemptContext;
 import org.apache.hadoop.mapreduce.lib.input.FileSplit;
 
-import org.apache.pig.data.Tuple;
-import org.apache.pig.data.TupleFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -31,25 +28,20 @@ import com.google.protobuf.Descriptors.Descriptor;
 import com.google.protobuf.Descriptors.FieldDescriptor;
 import com.google.protobuf.Message.Builder;
 import com.twitter.data.proto.Misc.ColumnarMetadata;
-import com.twitter.elephantbird.pig.util.ProtobufToPig;
-import com.twitter.elephantbird.pig.util.RCFileUtil;
+import com.twitter.elephantbird.util.RCFileUtil;
 import com.twitter.elephantbird.util.Protobufs;
 import com.twitter.elephantbird.util.TypeRef;
 
-public class RCFileProtobufInputFormat extends MapReduceInputFormatWrapper<LongWritable, Writable> {
+public class RCFileProtobufInputFormat extends RCFileBaseInputFormat {
 
   private static final Logger LOG = LoggerFactory.getLogger(RCFileProtobufInputFormat.class);
 
   private TypeRef<Message> typeRef;
 
-  /** internal, for MR use only. */
-  @SuppressWarnings({ "unchecked", "rawtypes" })
-  public RCFileProtobufInputFormat() {
-    super(new RCFileInputFormat());
-  }
+  // for MR
+  public  RCFileProtobufInputFormat() {}
 
   public RCFileProtobufInputFormat(TypeRef<Message> typeRef) {
-    this();
     this.typeRef = typeRef;
   }
 
@@ -61,18 +53,24 @@ public class RCFileProtobufInputFormat extends MapReduceInputFormatWrapper<LongW
     Protobufs.setClassConf(conf, RCFileProtobufInputFormat.class, protoClass);
   }
 
+  @Override
+  public RecordReader<LongWritable, Writable>
+  createRecordReader(InputSplit split, TaskAttemptContext taskAttempt)
+          throws IOException, InterruptedException {
+    if (typeRef == null) {
+      typeRef = Protobufs.getTypeRef(taskAttempt.getConfiguration(), RCFileProtobufInputFormat.class);
+    }
+    return new ProtobufReader(createUnwrappedRecordReader(split, taskAttempt));
+  }
+
   public class ProtobufReader extends FilterRecordReader<LongWritable, Writable> {
 
-    private final TupleFactory tf = TupleFactory.getInstance();
-    private final ProtobufToPig protoToPig = new ProtobufToPig();
+    protected Builder               msgBuilder;
+    protected boolean               readUnknownsColumn = false;
+    protected List<FieldDescriptor> knownRequiredFields = Lists.newArrayList();
+    protected ArrayList<Integer>    columnsBeingRead = Lists.newArrayList();
 
-    private Builder               msgBuilder;
-    private boolean               readUnknownsColumn = false;
-    private List<FieldDescriptor> knownRequiredFields = Lists.newArrayList();
-    private ArrayList<Integer>    columnsBeingRead = Lists.newArrayList();
-
-    private Message               currentValue;
-    private ProtobufWritable<Message> protoWritable;
+    protected ProtobufWritable<Message> protoWritable;
 
     /**
      * The reader is expected to be a
@@ -141,26 +139,21 @@ public class RCFileProtobufInputFormat extends MapReduceInputFormatWrapper<LongW
     }
 
     @Override
-    public boolean nextKeyValue() throws IOException, InterruptedException {
-      currentValue = null;
-      return super.nextKeyValue();
-    }
-
-    @Override
     public Writable getCurrentValue() throws IOException, InterruptedException {
       protoWritable.set(getCurrentProtobufValue());
       return protoWritable;
+    }
+
+    /** returns <code>super.getCurrentValue()</code> */
+    public BytesRefArrayWritable getCurrentBytesRefArrayWritable() throws IOException, InterruptedException {
+      return (BytesRefArrayWritable) super.getCurrentValue();
     }
 
     /**
      * Builds protobuf message from the raw bytes returned by RCFile reader.
      */
     public Message getCurrentProtobufValue() throws IOException, InterruptedException {
-      if (currentValue != null) {
-        return currentValue;
-      }
-
-      BytesRefArrayWritable byteRefs = (BytesRefArrayWritable) super.getCurrentValue();
+      BytesRefArrayWritable byteRefs = getCurrentBytesRefArrayWritable();
       if (byteRefs == null) {
         return null;
       }
@@ -186,54 +179,8 @@ public class RCFileProtobufInputFormat extends MapReduceInputFormatWrapper<LongW
         }
       }
 
-      currentValue = builder.build();
-      return currentValue;
-    }
-
-    /**
-     * Returns a Tuple consisting of required fields with out creating
-     * a Protobuf message at the top level.
-     */
-    public Tuple getCurrentTupleValue() throws IOException, InterruptedException {
-
-      BytesRefArrayWritable byteRefs = (BytesRefArrayWritable) super.getCurrentValue();
-      if (byteRefs == null) {
-        return null;
-      }
-
-      Tuple tuple = tf.newTuple(knownRequiredFields.size());
-
-      for (int i=0; i < knownRequiredFields.size(); i++) {
-        BytesRefWritable buf = byteRefs.get(columnsBeingRead.get(i));
-        FieldDescriptor fd = knownRequiredFields.get(i);
-        Object value = null;
-        if (buf.getLength() > 0) {
-          value = Protobufs.readFieldNoTag(
-              CodedInputStream.newInstance(buf.getData(), buf.getStart(), buf.getLength()),
-              knownRequiredFields.get(i),
-              msgBuilder);
-        } else if (fd.getType() != FieldDescriptor.Type.MESSAGE) {
-          value = fd.getDefaultValue();
-        }
-        tuple.set(i, protoToPig.fieldToPig(fd, value));
-      }
-
-      if (readUnknownsColumn) {
-        // we can handle this if needed.
-        throw new IOException("getCurrentTupleValue() is not supported when 'readUnknownColumns' is set");
-      }
-
-      return tuple;
+      return builder.build();
     }
   }
 
-  @Override
-  public RecordReader<LongWritable, Writable>
-  createRecordReader(InputSplit split, TaskAttemptContext taskAttempt)
-                                    throws IOException, InterruptedException {
-    if (typeRef == null) {
-      typeRef = Protobufs.getTypeRef(taskAttempt.getConfiguration(), RCFileProtobufInputFormat.class);
-    }
-    return new ProtobufReader(super.createRecordReader(split, taskAttempt));
-  }
-}
+ }

--- a/rcfile/src/main/java/com/twitter/elephantbird/mapreduce/input/RCFileProtobufTupleInputFormat.java
+++ b/rcfile/src/main/java/com/twitter/elephantbird/mapreduce/input/RCFileProtobufTupleInputFormat.java
@@ -1,0 +1,94 @@
+package com.twitter.elephantbird.mapreduce.input;
+
+import com.google.protobuf.CodedInputStream;
+import com.google.protobuf.Descriptors;
+import com.google.protobuf.Message;
+import com.twitter.elephantbird.pig.util.ProtobufToPig;
+import com.twitter.elephantbird.util.Protobufs;
+import com.twitter.elephantbird.util.TypeRef;
+import org.apache.hadoop.hive.serde2.columnar.BytesRefArrayWritable;
+import org.apache.hadoop.hive.serde2.columnar.BytesRefWritable;
+import org.apache.hadoop.io.LongWritable;
+import org.apache.hadoop.io.Writable;
+import org.apache.hadoop.mapreduce.InputSplit;
+import org.apache.hadoop.mapreduce.RecordReader;
+import org.apache.hadoop.mapreduce.TaskAttemptContext;
+import org.apache.pig.data.Tuple;
+import org.apache.pig.data.TupleFactory;
+
+import java.io.IOException;
+
+/**
+ * This is a wrapper over RCFileProtobufInputFormat and provides a method
+ * to create a Tuple directly from RCFile bytes, skipping building a protobuf
+ * first.
+ */
+public class RCFileProtobufTupleInputFormat extends RCFileProtobufInputFormat {
+
+  // for MR
+  public RCFileProtobufTupleInputFormat() {}
+
+  public RCFileProtobufTupleInputFormat(TypeRef<Message> typeRef) {
+    super(typeRef);
+  }
+
+  @Override
+  public RecordReader<LongWritable, Writable>
+  createRecordReader(InputSplit split, TaskAttemptContext taskAttempt)
+                                 throws IOException, InterruptedException {
+    return new TupleReader(createUnwrappedRecordReader(split, taskAttempt));
+  }
+
+  public class TupleReader extends ProtobufReader {
+
+    private final TupleFactory tf = TupleFactory.getInstance();
+    private final ProtobufToPig protoToPig = new ProtobufToPig();
+
+    /**
+     * The reader is expected to be a
+     * <code>RecordReader< LongWritable, BytesRefArrayWritable ></code>.
+     */
+    @SuppressWarnings({ "unchecked", "rawtypes" })
+    public TupleReader(RecordReader reader) {
+      super(reader);
+    }
+
+    /**
+     * Returns a Tuple consisting of required fields with out creating
+     * a Protobuf message at the top level.
+     */
+    public Tuple getCurrentTupleValue() throws IOException, InterruptedException {
+
+      BytesRefArrayWritable byteRefs = getCurrentBytesRefArrayWritable();
+
+      if (byteRefs == null) {
+        return null;
+      }
+
+      Tuple tuple = tf.newTuple(knownRequiredFields.size());
+
+      for (int i=0; i < knownRequiredFields.size(); i++) {
+        BytesRefWritable buf = byteRefs.get(columnsBeingRead.get(i));
+        Descriptors.FieldDescriptor fd = knownRequiredFields.get(i);
+        Object value = null;
+        if (buf.getLength() > 0) {
+          value = Protobufs.readFieldNoTag(
+                  CodedInputStream.newInstance(buf.getData(), buf.getStart(), buf.getLength()),
+                  knownRequiredFields.get(i),
+                  msgBuilder);
+        } else if (fd.getType() != Descriptors.FieldDescriptor.Type.MESSAGE) {
+          value = fd.getDefaultValue();
+        }
+        tuple.set(i, protoToPig.fieldToPig(fd, value));
+      }
+
+      if (isReadingUnknonwsColumn()) {
+        // we can handle this if needed.
+        throw new IOException("getCurrentTupleValue() is not supported when 'readUnknownColumns' is set");
+      }
+
+      return tuple;
+    }
+  }
+
+}

--- a/rcfile/src/main/java/com/twitter/elephantbird/mapreduce/input/RCFileThriftTupleInputFormat.java
+++ b/rcfile/src/main/java/com/twitter/elephantbird/mapreduce/input/RCFileThriftTupleInputFormat.java
@@ -1,0 +1,86 @@
+package com.twitter.elephantbird.mapreduce.input;
+
+import com.twitter.elephantbird.pig.util.ThriftToPig;
+import com.twitter.elephantbird.thrift.TStructDescriptor;
+import com.twitter.elephantbird.util.ThriftUtils;
+import com.twitter.elephantbird.util.TypeRef;
+import org.apache.hadoop.hive.serde2.columnar.BytesRefArrayWritable;
+import org.apache.hadoop.hive.serde2.columnar.BytesRefWritable;
+import org.apache.hadoop.io.LongWritable;
+import org.apache.hadoop.io.Writable;
+import org.apache.hadoop.mapreduce.InputSplit;
+import org.apache.hadoop.mapreduce.RecordReader;
+import org.apache.hadoop.mapreduce.TaskAttemptContext;
+import org.apache.pig.data.Tuple;
+import org.apache.pig.data.TupleFactory;
+import org.apache.thrift.TBase;
+import org.apache.thrift.TException;
+
+import java.io.IOException;
+
+/**
+ * This is a wrapper over RCFileThriftInputFormat and provides a method
+ * to create a Tuple directly from RCFile bytes, skipping building a Thrift
+ * object.
+ */
+public class RCFileThriftTupleInputFormat extends RCFileThriftInputFormat {
+
+  // for MR
+  public RCFileThriftTupleInputFormat() {}
+
+  public RCFileThriftTupleInputFormat(TypeRef<TBase<?, ?>> typeRef) {
+    super(typeRef);
+  }
+
+  @Override
+  public RecordReader<LongWritable, Writable>
+  createRecordReader(InputSplit split, TaskAttemptContext taskAttempt)
+                                     throws IOException, InterruptedException {
+    return new TupleReader(createUnwrappedRecordReader(split, taskAttempt));
+  }
+
+  public class TupleReader extends RCFileThriftInputFormat.ThriftReader {
+
+    private final TupleFactory tf = TupleFactory.getInstance();
+
+    /**
+     * The reader is expected to be a
+     * <code>RecordReader< LongWritable, BytesRefArrayWritable ></code>
+     */
+    @SuppressWarnings({ "unchecked", "rawtypes" })
+    public TupleReader(RecordReader reader) {
+      super(reader);
+    }
+
+    /**
+     * Returns a Tuple consisting of required fields with out creating
+     * a Thrift message at the top level.
+     */
+    public Tuple getCurrentTupleValue() throws IOException, InterruptedException, TException {
+
+      BytesRefArrayWritable byteRefs = getCurrentBytesRefArrayWritable();
+      if (byteRefs == null) {
+        return null;
+      }
+
+      Tuple tuple = tf.newTuple(knownRequiredFields.size());
+
+      for (int i=0; i < knownRequiredFields.size(); i++) {
+        BytesRefWritable buf = byteRefs.get(columnsBeingRead.get(i));
+        if (buf.getLength() > 0) {
+          memTransport.reset(buf.getData(), buf.getStart(), buf.getLength());
+
+          TStructDescriptor.Field field = knownRequiredFields.get(i);
+          Object value = ThriftUtils.readFieldNoTag(tProto, field);
+          tuple.set(i, ThriftToPig.toPigObject(field, value, false));
+        }
+      }
+
+      if (isReadingUnknonwsColumn()) {
+        throw new IOException("getCurrentTupleValue() is not supported when 'readUnknownColumns' is set");
+      }
+
+      return tuple;
+    }
+  }
+}

--- a/rcfile/src/main/java/com/twitter/elephantbird/mapreduce/output/RCFileOutputFormat.java
+++ b/rcfile/src/main/java/com/twitter/elephantbird/mapreduce/output/RCFileOutputFormat.java
@@ -19,7 +19,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.twitter.data.proto.Misc.ColumnarMetadata;
-import com.twitter.elephantbird.pig.util.RCFileUtil;
+import com.twitter.elephantbird.util.RCFileUtil;
 import com.twitter.elephantbird.util.Protobufs;
 
 /**

--- a/rcfile/src/main/java/com/twitter/elephantbird/mapreduce/output/RCFileThriftOutputFormat.java
+++ b/rcfile/src/main/java/com/twitter/elephantbird/mapreduce/output/RCFileThriftOutputFormat.java
@@ -107,7 +107,7 @@ public class RCFileThriftOutputFormat extends RCFileOutputFormat {
     public void write(NullWritable key, Writable value) throws IOException, InterruptedException {
       try {
         if (value instanceof BytesWritable) {
-          // TODO: handled errors
+          // TODO: handle errors
           fromBytes((BytesWritable)value);
         } else {
           fromObject((TBase<?, ?>)((ThriftWritable)value).get());

--- a/rcfile/src/main/java/com/twitter/elephantbird/pig/load/RCFileProtobufPigLoader.java
+++ b/rcfile/src/main/java/com/twitter/elephantbird/pig/load/RCFileProtobufPigLoader.java
@@ -2,6 +2,7 @@ package com.twitter.elephantbird.pig.load;
 
 import java.io.IOException;
 
+import com.twitter.elephantbird.mapreduce.input.RCFileProtobufTupleInputFormat;
 import org.apache.hadoop.mapreduce.InputFormat;
 import org.apache.hadoop.mapreduce.Job;
 import org.apache.hadoop.mapreduce.RecordReader;
@@ -9,16 +10,14 @@ import org.apache.pig.backend.hadoop.executionengine.mapReduceLayer.PigSplit;
 import org.apache.pig.data.Tuple;
 
 import com.google.protobuf.Message;
-import com.twitter.elephantbird.mapreduce.input.RCFileProtobufInputFormat;
-import com.twitter.elephantbird.pig.util.RCFileUtil;
-import com.twitter.elephantbird.util.TypeRef;
+import com.twitter.elephantbird.util.RCFileUtil;
 
 /**
  * Pig loader for Protobufs stored in RCFiles.
  */
 public class RCFileProtobufPigLoader extends ProtobufPigLoader<Message> {
 
-  private RCFileProtobufInputFormat.ProtobufReader protoReader;
+  private RCFileProtobufTupleInputFormat.TupleReader protoReader;
 
   /**
    * @param protoClassName fully qualified name of the protobuf class
@@ -29,7 +28,7 @@ public class RCFileProtobufPigLoader extends ProtobufPigLoader<Message> {
 
   @Override @SuppressWarnings("unchecked")
   public InputFormat getInputFormat() throws IOException {
-    return new RCFileProtobufInputFormat(typeRef);
+    return new RCFileProtobufTupleInputFormat(typeRef);
   }
 
   @Override
@@ -54,7 +53,7 @@ public class RCFileProtobufPigLoader extends ProtobufPigLoader<Message> {
   @Override @SuppressWarnings("unchecked")
   public void prepareToRead(RecordReader reader, PigSplit split) {
     super.prepareToRead(reader, split);
-    protoReader = (RCFileProtobufInputFormat.ProtobufReader) reader;
+    protoReader = (RCFileProtobufTupleInputFormat.TupleReader) reader;
   }
 
   @Override

--- a/rcfile/src/main/java/com/twitter/elephantbird/pig/load/RCFileThriftPigLoader.java
+++ b/rcfile/src/main/java/com/twitter/elephantbird/pig/load/RCFileThriftPigLoader.java
@@ -2,6 +2,7 @@ package com.twitter.elephantbird.pig.load;
 
 import java.io.IOException;
 
+import com.twitter.elephantbird.mapreduce.input.RCFileThriftTupleInputFormat;
 import org.apache.hadoop.mapreduce.InputFormat;
 import org.apache.hadoop.mapreduce.Job;
 import org.apache.hadoop.mapreduce.RecordReader;
@@ -11,15 +12,14 @@ import org.apache.thrift.TBase;
 import org.apache.thrift.TException;
 
 import com.twitter.elephantbird.mapreduce.input.RCFileThriftInputFormat;
-import com.twitter.elephantbird.pig.util.RCFileUtil;
-import com.twitter.elephantbird.util.TypeRef;
+import com.twitter.elephantbird.util.RCFileUtil;
 
 /**
  * Pig loader for Thrift object stored in RCFiles.
  */
 public class RCFileThriftPigLoader extends ThriftPigLoader<TBase<?,?>> {
 
-  private RCFileThriftInputFormat.ThriftReader thriftReader;
+  private RCFileThriftTupleInputFormat.TupleReader thriftReader;
 
   /**
    * @param thriftClassName fully qualified name of the thrift class
@@ -30,7 +30,7 @@ public class RCFileThriftPigLoader extends ThriftPigLoader<TBase<?,?>> {
 
   @Override @SuppressWarnings("unchecked")
   public InputFormat getInputFormat() throws IOException {
-    return new RCFileThriftInputFormat(typeRef);
+    return new RCFileThriftTupleInputFormat(typeRef);
   }
 
   @Override
@@ -57,7 +57,7 @@ public class RCFileThriftPigLoader extends ThriftPigLoader<TBase<?,?>> {
   @Override @SuppressWarnings("unchecked")
   public void prepareToRead(RecordReader reader, PigSplit split) {
     super.prepareToRead(reader, split);
-    thriftReader = (RCFileThriftInputFormat.ThriftReader) reader;
+    thriftReader = (RCFileThriftTupleInputFormat.TupleReader) reader;
   }
 
   @Override

--- a/rcfile/src/main/java/com/twitter/elephantbird/util/RCFileUtil.java
+++ b/rcfile/src/main/java/com/twitter/elephantbird/util/RCFileUtil.java
@@ -1,4 +1,4 @@
-package com.twitter.elephantbird.pig.util;
+package com.twitter.elephantbird.util;
 
 import java.io.IOException;
 import java.lang.reflect.Field;
@@ -19,7 +19,6 @@ import org.slf4j.LoggerFactory;
 import com.google.common.base.Joiner;
 import com.google.common.collect.Lists;
 import com.twitter.data.proto.Misc.ColumnarMetadata;
-import com.twitter.elephantbird.util.Protobufs;
 
 public class RCFileUtil {
 


### PR DESCRIPTION
This patch does two things : 

  1) Thrift and Protobuf record readers return ThriftWritable and ProtobufWritable in getCurrentValues(). Earlier these returned raw bytes, and not really useful for anyone using the inputformat directly (e.g. Scalding/Cascading, or put MR program).

  2) move Pig tuple handling to its own class so that MR apps don't need Pig jars.

There is some minor restructuring.
All of the new code is exercised in unit tests (Pig loaders there invoke both getCurrentValue() as well as getCurrentTupleValue() depending on whether there are "unknown fields" in input. 
