### PR TITLE
set test.build.data system property (lost in ivy to mvn migration)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -319,22 +319,19 @@
         </plugin>
         <plugin>
           <artifactId>maven-surefire-plugin</artifactId>
-          <version>2.12</version>
+          <version>2.12.4</version>
           <dependencies>
             <dependency>
               <groupId>org.apache.maven.surefire</groupId>
               <artifactId>surefire-junit47</artifactId>
-              <version>2.12</version>
+              <version>2.12.4</version>
             </dependency>
           </dependencies>
           <configuration>
             <redirectTestOutputToFile>true</redirectTestOutputToFile>
-            <systemProperties>
-              <property>
-                <name>test.build.data</name>
-                <value>${basedir}/target/surefire/data</value>
-              </property>
-            </systemProperties>
+            <systemPropertyVariables>
+              <test.build.data>${basedir}/target/surefire/data</test.build.data>
+            </systemPropertyVariables>
             <argLine>-Djava.library.path=${test.library.path}</argLine>
           </configuration>
         </plugin>


### PR DESCRIPTION
set test.build.data system property used in various tests.
