### PR TITLE
Add new ProtobufDeserializer with ProtobufStructObjectInspector.

### DIFF
--- a/hive/src/main/java/com/twitter/elephantbird/hive/serde/ProtobufStructObjectInspector.java
+++ b/hive/src/main/java/com/twitter/elephantbird/hive/serde/ProtobufStructObjectInspector.java
@@ -1,0 +1,174 @@
+package com.twitter.elephantbird.hive.serde;
+
+import java.util.List;
+
+import com.google.common.collect.Lists;
+import com.google.protobuf.Descriptors.Descriptor;
+import com.google.protobuf.Descriptors.FieldDescriptor;
+import com.google.protobuf.Descriptors.FieldDescriptor.JavaType;
+import com.google.protobuf.Message;
+
+import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector;
+import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspectorFactory;
+import org.apache.hadoop.hive.serde2.objectinspector.PrimitiveObjectInspector.PrimitiveCategory;
+import org.apache.hadoop.hive.serde2.objectinspector.SettableStructObjectInspector;
+import org.apache.hadoop.hive.serde2.objectinspector.StructField;
+import org.apache.hadoop.hive.serde2.objectinspector.primitive.PrimitiveObjectInspectorFactory;
+
+public final class ProtobufStructObjectInspector extends SettableStructObjectInspector {
+
+  public static class ProtobufStructField implements StructField {
+
+    private ObjectInspector oi = null;
+    private String comment = null;
+    private FieldDescriptor fieldDescriptor;
+
+    public ProtobufStructField(FieldDescriptor fieldDescriptor) {
+      this.fieldDescriptor = fieldDescriptor;
+      oi = this.createOIForField();
+    }
+
+    @Override
+    public String getFieldName() {
+      return fieldDescriptor.getName();
+    }
+
+    @Override
+    public ObjectInspector getFieldObjectInspector() {
+      return oi;
+    }
+
+    @Override
+    public String getFieldComment() {
+      return comment;
+    }
+
+    public FieldDescriptor getFieldDescriptor() {
+      return fieldDescriptor;
+    }
+
+    private PrimitiveCategory getPrimitiveCategory(JavaType fieldType) {
+      switch (fieldType) {
+        case INT:
+          return PrimitiveCategory.INT;
+        case LONG:
+          return PrimitiveCategory.LONG;
+        case FLOAT:
+          return PrimitiveCategory.FLOAT;
+        case DOUBLE:
+          return PrimitiveCategory.DOUBLE;
+        case BOOLEAN:
+          return PrimitiveCategory.BOOLEAN;
+        case STRING:
+          return PrimitiveCategory.STRING;
+        case BYTE_STRING:
+          return PrimitiveCategory.BINARY;
+        case ENUM:
+          return PrimitiveCategory.STRING;
+        default:
+          return null;
+      }
+    }
+
+    private ObjectInspector createOIForField() {
+      JavaType fieldType = fieldDescriptor.getJavaType();
+      PrimitiveCategory category = getPrimitiveCategory(fieldType);
+      ObjectInspector elementOI = null;
+      if (category != null) {
+        elementOI = PrimitiveObjectInspectorFactory.getPrimitiveJavaObjectInspector(category);
+      } else {
+        switch (fieldType) {
+          case MESSAGE:
+            elementOI = new ProtobufStructObjectInspector(fieldDescriptor.getMessageType());
+            break;
+          default:
+            throw new RuntimeException("JavaType " + fieldType
+                + " from protobuf is not supported.");
+        }
+      }
+      if (fieldDescriptor.isRepeated()) {
+        return ObjectInspectorFactory.getStandardListObjectInspector(elementOI);
+      } else {
+        return elementOI;
+      }
+    }
+  }
+
+  private Descriptor descriptor;
+  private List<StructField> structFields = Lists.newArrayList();
+
+  ProtobufStructObjectInspector(Descriptor descriptor) {
+    this.descriptor = descriptor;
+    for (FieldDescriptor fd : descriptor.getFields()) {
+      structFields.add(new ProtobufStructField(fd));
+    }
+  }
+
+  @Override
+  public Category getCategory() {
+    return Category.STRUCT;
+  }
+
+  @Override
+  public String getTypeName() {
+    StringBuilder sb = new StringBuilder("struct<");
+    boolean first = true;
+    for (StructField structField : getAllStructFieldRefs()) {
+      if (first) {
+        first = false;
+      } else {
+        sb.append(",");
+      }
+      sb.append(structField.getFieldName()).append(":")
+          .append(structField.getFieldObjectInspector().getTypeName());
+    }
+    sb.append(">");
+    return sb.toString();
+  }
+
+  @Override
+  public Object create() {
+    return descriptor.toProto().toBuilder().build();
+  }
+
+  @Override
+  public Object setStructFieldData(Object data, StructField field, Object fieldValue) {
+    return ((Message) data)
+        .toBuilder()
+        .setField(descriptor.findFieldByName(field.getFieldName()), fieldValue)
+        .build();
+  }
+
+  @Override
+  public List<? extends StructField> getAllStructFieldRefs() {
+    return structFields;
+  }
+
+  @Override
+  public Object getStructFieldData(Object data, StructField structField) {
+    if (data == null) {
+      return null;
+    }
+    Message m = (Message) data;
+    ProtobufStructField psf = (ProtobufStructField) structField;
+    return m.getField(psf.getFieldDescriptor());
+  }
+
+  @Override
+  public StructField getStructFieldRef(String fieldName) {
+    return new ProtobufStructField(descriptor.findFieldByName(fieldName));
+  }
+
+  @Override
+  public List<Object> getStructFieldsDataAsList(Object data) {
+    if (data == null) {
+      return null;
+    }
+    List<Object> result = Lists.newArrayList();
+    Message m = (Message) data;
+    for (FieldDescriptor fd : descriptor.getFields()) {
+      result.add(m.getField(fd));
+    }
+    return result;
+  }
+}

--- a/hive/src/test/java/com/twitter/elephantbird/hive/serde/ProtobufDeserializerTest.java
+++ b/hive/src/test/java/com/twitter/elephantbird/hive/serde/ProtobufDeserializerTest.java
@@ -1,0 +1,109 @@
+package com.twitter.elephantbird.hive.serde;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.util.List;
+import java.util.Properties;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hive.serde2.SerDeException;
+import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector;
+import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector.Category;
+import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspectorFactory;
+import org.apache.hadoop.hive.serde2.objectinspector.StandardListObjectInspector;
+import org.apache.hadoop.io.BytesWritable;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.twitter.data.proto.tutorial.AddressBookProtos.AddressBook;
+import com.twitter.data.proto.tutorial.AddressBookProtos.Person;
+import com.twitter.data.proto.tutorial.AddressBookProtos.Person.PhoneNumber;
+import com.twitter.data.proto.tutorial.AddressBookProtos.Person.PhoneType;
+
+public class ProtobufDeserializerTest {
+
+  private AddressBook test_ab;
+  private PhoneNumber test_pn;
+  private ProtobufDeserializer deserializer;
+
+  @Before
+  public void setUp() throws SerDeException {
+    PhoneNumber pn1 = PhoneNumber.newBuilder().setNumber("pn0001").setType(PhoneType.HOME).build();
+    PhoneNumber pn2 = PhoneNumber.newBuilder().setNumber("pn0002").setType(PhoneType.WORK).build();
+    PhoneNumber pn3 = PhoneNumber.newBuilder().setNumber("pn0003").build();
+    test_pn = PhoneNumber.newBuilder().setNumber("pn0004").setType(PhoneType.MOBILE)
+        .build();
+
+    Person p1 = Person.newBuilder().setName("p1").setId(1).setEmail("p1@twitter").addPhone(pn1)
+        .addPhone(pn2).addPhone(pn3).build();
+    Person p2 = Person.newBuilder().setName("p2").setId(2).addPhone(test_pn).build();
+    Person p3 = Person.newBuilder().setName("p3").setId(3).build();
+
+    test_ab = AddressBook.newBuilder().addPerson(p1).addPerson(p2).addPerson(p3).build();
+    deserializer = new ProtobufDeserializer();
+
+    Properties properties = new Properties();
+    properties.setProperty(org.apache.hadoop.hive.serde.Constants.SERIALIZATION_CLASS,
+        AddressBook.class.getName());
+    deserializer.initialize(new Configuration(), properties);
+  }
+
+  @Test
+  public final void testDeserializer() throws SerDeException {
+    BytesWritable serialized = new BytesWritable(test_ab.toByteArray());
+    AddressBook ab2 = (AddressBook) deserializer.deserialize(serialized);
+    assertTrue(test_ab.equals(ab2));
+  }
+
+  @Test
+  public final void testObjectInspector() throws SerDeException {
+    ObjectInspector oi = deserializer.getObjectInspector();
+    assertEquals(oi.getCategory(), Category.STRUCT);
+
+    ProtobufStructObjectInspector protobufOI = (ProtobufStructObjectInspector) oi;
+    List<Object> readData = protobufOI.getStructFieldsDataAsList(test_ab);
+
+    assertEquals(readData.size(), 1);
+    @SuppressWarnings("unchecked")
+    List<Person> persons = (List<Person>) readData.get(0);
+    assertEquals(persons.size(), 3);
+    assertEquals(persons.get(0).getPhoneCount(), 3);
+    assertEquals(persons.get(0).getPhone(2).getType(), PhoneType.HOME);
+    assertEquals(persons.get(0).getId(), 1);
+
+    assertEquals(persons.get(1).getPhoneCount(), 1);
+    assertEquals(persons.get(1).getPhone(0), test_pn);
+    assertEquals(persons.get(1).getPhone(0).getType(), PhoneType.MOBILE);
+
+    assertEquals(persons.get(2).getPhoneCount(), 0);
+    assertEquals(persons.get(2).getId(), 3);
+    assertEquals(persons.get(2).getEmail(), "");
+  }
+
+  @Test
+  public final void testObjectInspectorGetTypeName() throws SerDeException {
+    ProtobufStructObjectInspector protobufOI = (ProtobufStructObjectInspector) deserializer
+        .getObjectInspector();
+    assertEquals(protobufOI.getTypeName(),
+        "struct<person:array<"
+            + "struct<name:string,id:int,email:string,"
+            + "phone:array<struct<number:string,type:string>>>>>");
+  }
+
+  @Test
+  public final void testElementObjectInspector() throws SerDeException {
+    ProtobufStructObjectInspector protobufOI = (ProtobufStructObjectInspector) deserializer
+        .getObjectInspector();
+
+    ProtobufStructObjectInspector personOI = new ProtobufStructObjectInspector(
+        Person.getDescriptor());
+    assertEquals(protobufOI.getStructFieldRef("person").getFieldObjectInspector().getClass(),
+        ObjectInspectorFactory.getStandardListObjectInspector(personOI).getClass());
+
+    StandardListObjectInspector phoneOI = (StandardListObjectInspector) personOI.getStructFieldRef(
+        "phone").getFieldObjectInspector();
+    assertEquals(phoneOI.getListElementObjectInspector().getTypeName(),
+        "struct<number:string,type:string>");
+  }
+}


### PR DESCRIPTION
The current ProtobufDeserializers in Hive and EB depend on the stock ReflectionObjectInspector and have various issues when reading protobuf data. We provide a new ProtobufStructObjectInspector to use native protobuf functions through its Descriptor interface instead of reflection-based method used in Hive.
