### PR TITLE
catch runtime exceptions in ThriftConverter

### DIFF
--- a/core/src/main/java/com/twitter/elephantbird/mapreduce/io/ThriftConverter.java
+++ b/core/src/main/java/com/twitter/elephantbird/mapreduce/io/ThriftConverter.java
@@ -53,11 +53,9 @@ public class ThriftConverter<M extends TBase<?, ?>> implements BinaryConverter<M
       M message = typeRef.safeNewInstance();
       deserializer.deserialize(message, messageBuffer);
       return message;
-    } catch (TException e) {
-      logWarning("failed to deserialize", e);
-      return null;
     } catch (Throwable e) {
-      // Arbitrary bytes can cause a runtime exception in Thrift
+      // normally a TException. but some corrupt records can cause
+      // other runtime exceptions (e.g. IndexOutOfBoundsException).
       logWarning("failed to deserialize", e);
       return null;
     }


### PR DESCRIPTION
Our intention in ThriftConverter is to catch all the exception in case of corrupt / incorrect records. Some of these records can result in runtime exception (often IndexOutOfBound exception).
