### PR TITLE
catch protobuf errors during block decoding (up to bad records threshold)

### DIFF
--- a/core/src/main/java/com/twitter/elephantbird/mapreduce/input/LzoBinaryBlockRecordReader.java
+++ b/core/src/main/java/com/twitter/elephantbird/mapreduce/input/LzoBinaryBlockRecordReader.java
@@ -3,6 +3,7 @@ package com.twitter.elephantbird.mapreduce.input;
 import java.io.IOException;
 import java.io.InputStream;
 
+import com.google.protobuf.InvalidProtocolBufferException;
 import com.twitter.elephantbird.mapreduce.io.BinaryBlockReader;
 import com.twitter.elephantbird.mapreduce.io.BinaryWritable;
 import com.twitter.elephantbird.util.HadoopUtils;
@@ -118,7 +119,10 @@ public class LzoBinaryBlockRecordReader<M, W extends BinaryWritable<M>> extends 
         if (!reader_.readNext(value_)) {
           return false; // EOF
         }
+      } catch (InvalidProtocolBufferException e) {
+        decodeException = e;
       } catch (IOException e) {
+        // Re-throw IOExceptions that are not due to protobuf decode errors
         throw e;
       } catch (Throwable e) {
         decodeException = e;


### PR DESCRIPTION
elephant-bird catches many exceptions related to data corruption, but it lets through exceptions of type com.google.protobuf.InvalidProtocolBufferException (because they're IOExceptions).  This patch special-cases this particular exception and increments the bad records count instead of re-throwing it.
