### PR TITLE
Make travis-ci work

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,13 +5,7 @@ jdk:
 
 before_install:
   - sudo apt-get update -qq
-  - wget http://protobuf.googlecode.com/files/protobuf-2.3.0.tar.gz
-  - tar zxf protobuf-2.3.0.tar.gz
-  - cd protobuf-2.3.0
-  - ./configure --prefix=/usr
-  - make
-  - sudo make install
-  - cd ..
+  - sudo apt-get install -qq protobuf-compiler
   - sudo apt-get install -qq libboost-dev libboost-test-dev libboost-program-options-dev libevent-dev automake libtool flex bison pkg-config g++ libssl-dev
   - wget -nv http://archive.apache.org/dist/thrift/0.7.0/thrift-0.7.0.tar.gz
   - tar zxf thrift-0.7.0.tar.gz

--- a/Readme.md
+++ b/Readme.md
@@ -33,7 +33,7 @@ Elephant Bird release artifacts are published to the [Sonatype OSS](https://oss.
 
 ## Version compatibility
 
-1. Protocol Buffers 2.3 (not compatible with 2.4+)
+1. Protocol Buffers 2.3.0, 2.4.1
 2. Pig 0.8, 0.9 (not compatible with 0.7 and below)
 4. Hive 0.7 (with HIVE-1616)
 5. Thrift 0.5.0, 0.6.0, 0.7.0

--- a/pom.xml
+++ b/pom.xml
@@ -220,7 +220,7 @@
       <dependency>
         <groupId>com.google.protobuf</groupId>
         <artifactId>protobuf-java</artifactId>
-        <version>2.3.0</version>
+        <version>2.4.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.thrift</groupId>


### PR DESCRIPTION
The current .travis.yml is not written correctly to build EB.  This patch makes travis-ci build EB correctly.
