### PR TITLE
Lower required maven version to 3.0.0 (currently 3.0.4)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -354,7 +354,7 @@
             <configuration>
               <rules>
                 <requireMavenVersion>
-                  <version>[3.0.4,)</version>
+                  <version>[3.0.0,)</version>
                 </requireMavenVersion>
               </rules>
               <fail>true</fail>


### PR DESCRIPTION
OSX 10.8 Mountain Lion ships with mvn 3.0.3:

fynn-2:elephant-bird travis$ mvn -version
Apache Maven 3.0.3 (r1075438; 2011-02-28 09:31:09-0800)
Maven home: /usr/share/maven
Java version: 1.6.0_35, vendor: Apple Inc.
Java home: /Library/Java/JavaVirtualMachines/1.6.0_35-b10-428.jdk/Contents/Home
Default locale: en_US, platform encoding: MacRoman
OS name: "mac os x", version: "10.8.2", arch: "x86_64", family: "mac"
fynn-2:elephant-bird travis$ 

So developers on OSX can use the default maven we should lower the required version to just 3.0.0 as it has all the features we require.
