### PR TITLE
Clarified the main requirements for building Elephant Bird from source

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -12,6 +12,8 @@ Apache licensed.
 
 ## Quickstart
 
+1. Ensure you are running on a Fedora based system
+1. Install the correct versions of the dependencies (see below)
 1. Get the code: `git clone git://github.com/kevinweil/elephant-bird.git`
 1. Build the jar: `mvn package`
 1. Explore what's available: `mvn javadoc:javadoc`


### PR DESCRIPTION
I spent a lot of time figuring out why I couldn't get the sources to build under CentOS. It turns out that some Fedora specific things are used (like mvn-rpmbuild ) and that the code is very limited to specific versions of things like protobuf and thrift.

This patch simply points out these requirements in the readme.
