### PR TITLE
enforce error threshold at the end of reading a split

### DIFF
--- a/core/src/main/java/com/twitter/elephantbird/mapreduce/input/LzoBinaryB64LineRecordReader.java
+++ b/core/src/main/java/com/twitter/elephantbird/mapreduce/input/LzoBinaryB64LineRecordReader.java
@@ -53,6 +53,7 @@ public class  LzoBinaryB64LineRecordReader<M, W extends BinaryWritable<M>> exten
 
   @Override
   public synchronized void close() throws IOException {
+    super.close();
     if (lineReader_ != null) {
       lineReader_.close();
     }

--- a/core/src/main/java/com/twitter/elephantbird/mapreduce/input/LzoBinaryBlockRecordReader.java
+++ b/core/src/main/java/com/twitter/elephantbird/mapreduce/input/LzoBinaryBlockRecordReader.java
@@ -55,6 +55,7 @@ public class LzoBinaryBlockRecordReader<M, W extends BinaryWritable<M>> extends 
 
   @Override
   public synchronized void close() throws IOException {
+    super.close();
     if (reader_ != null) {
       reader_.close();
     }

--- a/core/src/main/java/com/twitter/elephantbird/mapreduce/input/LzoGenericProtobufBlockRecordReader.java
+++ b/core/src/main/java/com/twitter/elephantbird/mapreduce/input/LzoGenericProtobufBlockRecordReader.java
@@ -34,6 +34,7 @@ public class LzoGenericProtobufBlockRecordReader extends LzoRecordReader<LongWri
 
   @Override
   public synchronized void close() throws IOException {
+    super.close();
     if (reader_ != null) {
       reader_.close();
     }

--- a/core/src/main/java/com/twitter/elephantbird/mapreduce/input/LzoJsonRecordReader.java
+++ b/core/src/main/java/com/twitter/elephantbird/mapreduce/input/LzoJsonRecordReader.java
@@ -33,6 +33,7 @@ public class LzoJsonRecordReader extends LzoRecordReader<LongWritable, MapWritab
 
   @Override
   public synchronized void close() throws IOException {
+    super.close();
     if (in_ != null) {
       in_.close();
     }

--- a/core/src/main/java/com/twitter/elephantbird/mapreduce/input/LzoLineRecordReader.java
+++ b/core/src/main/java/com/twitter/elephantbird/mapreduce/input/LzoLineRecordReader.java
@@ -21,6 +21,7 @@ public class LzoLineRecordReader extends LzoRecordReader<LongWritable, Text> {
 
   @Override
   public synchronized void close() throws IOException {
+    super.close();
     if (in_ != null) {
       in_.close();
     }

--- a/core/src/main/java/com/twitter/elephantbird/mapreduce/input/LzoW3CLogRecordReader.java
+++ b/core/src/main/java/com/twitter/elephantbird/mapreduce/input/LzoW3CLogRecordReader.java
@@ -37,6 +37,7 @@ public abstract class LzoW3CLogRecordReader extends LzoRecordReader<LongWritable
 
   @Override
   public synchronized void close() throws IOException {
+    super.close();
     if (in_ != null) {
       in_.close();
     }


### PR DESCRIPTION
enforce error threshold at the end of reading a split. This avoids spurious triggers where a split contains a few bad records early in the split, rather than at the end.

Though not usually required, it can be disabled by setting
"elephantbird.mapred.input.bad.record.check.only.in.close" to "false"
