### PR TITLE
Add getTypeDef for querying the Protobuf class in a ProtobufWritable directly

### DIFF
--- a/core/src/main/java/com/twitter/elephantbird/mapreduce/io/ProtobufWritable.java
+++ b/core/src/main/java/com/twitter/elephantbird/mapreduce/io/ProtobufWritable.java
@@ -40,6 +40,6 @@ public class ProtobufWritable<M extends Message> extends BinaryWritable<M> {
    * Returns the TypeRef for the Protobuf class.
    */
   public TypeRef<M> getTypeRef() {
-	return typeRef;
+    return typeRef;
   }
 }


### PR DESCRIPTION
Hi,

Here is an attempt to add a getTypeDef method for querying the Protobuf class in a ProtobufWritable directly. As I have mentioned in issue #327, with the help of  getTypeDef, we do not need to require users to provide the Protobuf class name if we get the ProtobufWritable.

Any comments would be appreciated.

Thanks
