### PR TITLE
option to limit size of input lines read into memory

### DIFF
--- a/core/src/main/java/com/twitter/elephantbird/mapreduce/input/LzoLineRecordReader.java
+++ b/core/src/main/java/com/twitter/elephantbird/mapreduce/input/LzoLineRecordReader.java
@@ -10,14 +10,25 @@ import org.apache.hadoop.util.LineReader;
 
 /**
  * Reads line from an lzo compressed text file. Treats keys as offset in file
- * and value as line.
+ * and value as line. <p>
+ *
+ * Set <code>{@value #MAX_LINE_LEN_CONF}</code> in order to limit size of
+ * a line read into memory. Otherwise, some very long lines (100s of MB long)
+ * could cause OOM errors and other timeouts.
  */
 public class LzoLineRecordReader extends LzoRecordReader<LongWritable, Text> {
+
+  /**
+   * Sets maximum number of bytes to read into memory when the input line is very long.
+   * The line read is truncated to this size.
+   */
+  public static final String MAX_LINE_LEN_CONF = "elephantbird.line.recordreader.max.line.length";
 
   private LineReader in_;
 
   private final LongWritable key_ = new LongWritable();
   private final Text value_ = new Text();
+  private int maxLineLen = Integer.MAX_VALUE;
 
   @Override
   public synchronized void close() throws IOException {
@@ -39,13 +50,14 @@ public class LzoLineRecordReader extends LzoRecordReader<LongWritable, Text> {
 
   @Override
   protected void createInputReader(InputStream input, Configuration conf) throws IOException {
+    maxLineLen = conf.getInt(MAX_LINE_LEN_CONF, Integer.MAX_VALUE);
     in_ = new LineReader(input, conf);
   }
 
   @Override
   protected void skipToNextSyncPoint(boolean atFirstRecord) throws IOException {
     if (!atFirstRecord) {
-      in_.readLine(new Text());
+      in_.readLine(new Text(), maxLineLen);
     }
   }
 
@@ -56,7 +68,7 @@ public class LzoLineRecordReader extends LzoRecordReader<LongWritable, Text> {
     if (pos_ <= end_) {
       key_.set(pos_);
 
-      int newSize = in_.readLine(value_);
+      int newSize = in_.readLine(value_, maxLineLen);
       if (newSize == 0) {
         return false;
       }


### PR DESCRIPTION
Otherwise, very large lines (result of some other bugs) cause hard failures.
