### PR TITLE
fix incorrect tuple key name in the VectorWritableConverter javadoc

### DIFF
--- a/mahout/src/main/java/com/twitter/elephantbird/pig/mahout/VectorWritableConverter.java
+++ b/mahout/src/main/java/com/twitter/elephantbird/pig/mahout/VectorWritableConverter.java
@@ -51,7 +51,7 @@ import com.twitter.elephantbird.pig.util.PigUtil;
  * is assumed:
  *
  * <pre>
- * (cardinality: int, entries: {entry: (index: int, value: double)})
+ * (cardinality: int, entries: {t: (index: int, value: double)})
  * </pre>
  *
  * If options {@code -sparse} and {@code -cardinality} are both specified, the following schema is


### PR DESCRIPTION
key was documented as "entry" but in reality it is "t"
