### PR TITLE
Update hadoop-lzo build in Travic-CI config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,8 +17,8 @@ before_install:
   - sudo apt-get -qq install lzop liblzo2-dev # libzo2-dev for compiling hadoop-lzo
   - git clone git://github.com/twitter/hadoop-lzo.git # for native libgplcompression
   - cd hadoop-lzo
-  - ant compile-native
-  - mv build/native/Linux-* ../hadoop-lzo-native
+  - mvn package -DskipTests
+  - mv target/native/Linux-* ../hadoop-lzo-native
   - cd ..
 
 script:


### PR DESCRIPTION
hadoop-lzo build switched to mvn build. We could fetch a specific version of hadoop-lzo. But elephant-bird and hadoop-lzo are often used together. Breakage in one should affect the other.
