### PR TITLE
Fixup broken links to internal source files

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -67,7 +67,7 @@ Additionally, protocol buffers and thrift messages can be stored in a variety of
 
 Hadoop provides two API implementations: the the old-style `org.apache.hadoop.mapred` and new-style `org.apache.hadoop.mapreduce` packages. Elephant-Bird provides wrapper classes that allow unmodified usage of `mapreduce` input and output formats in contexts where the `mapred` interface is required.
 
-For more information, see [DeprecatedInputFormatWrapper.java](https://github.com/kevinweil/elephant-bird/blob/master/core/src/java/com/twitter/elephantbird/mapred/input/DeprecatedInputFormatWrapper.java) and [DeprecatedOutputFormatWrapper.java](https://github.com/kevinweil/elephant-bird/blob/master/core/src/java/com/twitter/elephantbird/mapred/output/DeprecatedOutputFormatWrapper.java)
+For more information, see [DeprecatedInputFormatWrapper.java](https://github.com/kevinweil/elephant-bird/blob/master/core/src/main/java/com/twitter/elephantbird/mapred/input/DeprecatedInputFormatWrapper.java) and [DeprecatedOutputFormatWrapper.java](https://github.com/kevinweil/elephant-bird/blob/master/core/src/main/java/com/twitter/elephantbird/mapred/output/DeprecatedOutputFormatWrapper.java)
 
 
 ### Hadoop 2.x Support
@@ -120,11 +120,11 @@ the dynamic bits.
 ## Hadoop SequenceFiles and Pig
 
 Reading and writing Hadoop SequenceFiles with Pig is supported via classes
-[SequenceFileLoader](https://github.com/kevinweil/elephant-bird/blob/master/pig/src/java/com/twitter/elephantbird/pig/load/SequenceFileLoader.java)
+[SequenceFileLoader](https://github.com/kevinweil/elephant-bird/blob/master/pig/src/main/java/com/twitter/elephantbird/pig/load/SequenceFileLoader.java)
 and
-[SequenceFileStorage](https://github.com/kevinweil/elephant-bird/blob/master/pig/src/java/com/twitter/elephantbird/pig/store/SequenceFileStorage.java). These
+[SequenceFileStorage](https://github.com/kevinweil/elephant-bird/blob/master/pig/src/main/java/com/twitter/elephantbird/pig/store/SequenceFileStorage.java). These
 classes make use of a
-[WritableConverter](https://github.com/kevinweil/elephant-bird/blob/master/pig/src/java/com/twitter/elephantbird/pig/util/WritableConverter.java)
+[WritableConverter](https://github.com/kevinweil/elephant-bird/blob/master/pig/src/main/java/com/twitter/elephantbird/pig/util/WritableConverter.java)
 interface, allowing pluggable conversion of key and value instances to and from
 Pig data types.
 
@@ -155,11 +155,11 @@ STORE pairs INTO 'output' USING $SEQFILE_STORAGE (
 ```
 
 For details, please see Javadocs in the following classes:
-* [SequenceFileLoader](https://github.com/kevinweil/elephant-bird/blob/master/pig/src/java/com/twitter/elephantbird/pig/load/SequenceFileLoader.java)
-* [SequenceFileStorage](https://github.com/kevinweil/elephant-bird/blob/master/pig/src/java/com/twitter/elephantbird/pig/store/SequenceFileStorage.java)
-* [WritableConverter](https://github.com/kevinweil/elephant-bird/blob/master/pig/src/java/com/twitter/elephantbird/pig/util/WritableConverter.java)
-* [GenericWritableConverter](https://github.com/kevinweil/elephant-bird/blob/master/pig/src/java/com/twitter/elephantbird/pig/util/GenericWritableConverter.java)
-* [AbstractWritableConverter](https://github.com/kevinweil/elephant-bird/blob/master/pig/src/java/com/twitter/elephantbird/pig/util/AbstractWritableConverter.java)
+* [SequenceFileLoader](https://github.com/kevinweil/elephant-bird/blob/master/pig/src/main/java/com/twitter/elephantbird/pig/load/SequenceFileLoader.java)
+* [SequenceFileStorage](https://github.com/kevinweil/elephant-bird/blob/master/pig/src/main/java/com/twitter/elephantbird/pig/store/SequenceFileStorage.java)
+* [WritableConverter](https://github.com/kevinweil/elephant-bird/blob/master/pig/src/main/java/com/twitter/elephantbird/pig/util/WritableConverter.java)
+* [GenericWritableConverter](https://github.com/kevinweil/elephant-bird/blob/master/pig/src/main/java/com/twitter/elephantbird/pig/util/GenericWritableConverter.java)
+* [AbstractWritableConverter](https://github.com/kevinweil/elephant-bird/blob/master/pig/src/main/java/com/twitter/elephantbird/pig/util/AbstractWritableConverter.java)
 
 ## How To Contribute
 


### PR DESCRIPTION
Some links broke when layour went from src/java to maven style src/main/java - this fixes those up.
