### PR TITLE
Bumps EB versions from 4.1-SNAPSHOT to 4.2-SNAPSHOT

### DIFF
--- a/cascading2/pom.xml
+++ b/cascading2/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.twitter.elephantbird</groupId>
     <artifactId>elephant-bird</artifactId>
-    <version>4.1-SNAPSHOT</version>
+    <version>4.2-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.twitter.elephantbird</groupId>
     <artifactId>elephant-bird</artifactId>
-    <version>4.1-SNAPSHOT</version>
+    <version>4.2-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.twitter.elephantbird</groupId>
     <artifactId>elephant-bird</artifactId>
-    <version>4.1-SNAPSHOT</version>
+    <version>4.2-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/hadoop-compat/pom.xml
+++ b/hadoop-compat/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.twitter.elephantbird</groupId>
     <artifactId>elephant-bird</artifactId>
-    <version>4.1-SNAPSHOT</version>
+    <version>4.2-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/hive/pom.xml
+++ b/hive/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.twitter.elephantbird</groupId>
     <artifactId>elephant-bird</artifactId>
-    <version>4.1-SNAPSHOT</version>
+    <version>4.2-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/lucene/pom.xml
+++ b/lucene/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.twitter.elephantbird</groupId>
     <artifactId>elephant-bird</artifactId>
-    <version>4.1-SNAPSHOT</version>
+    <version>4.2-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/mahout/pom.xml
+++ b/mahout/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.twitter.elephantbird</groupId>
     <artifactId>elephant-bird</artifactId>
-    <version>4.1-SNAPSHOT</version>
+    <version>4.2-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/pig-lucene/pom.xml
+++ b/pig-lucene/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.twitter.elephantbird</groupId>
     <artifactId>elephant-bird</artifactId>
-    <version>4.1-SNAPSHOT</version>
+    <version>4.2-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/pig/pom.xml
+++ b/pig/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.twitter.elephantbird</groupId>
     <artifactId>elephant-bird</artifactId>
-    <version>4.1-SNAPSHOT</version>
+    <version>4.2-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
 
   <groupId>com.twitter.elephantbird</groupId>
   <artifactId>elephant-bird</artifactId>
-  <version>4.1-SNAPSHOT</version>
+  <version>4.2-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <name>Elephant Bird</name>
@@ -539,7 +539,7 @@
         </plugin>
         <plugin>
           <artifactId>maven-release-plugin</artifactId>
-          <version>2.3</version>
+          <version>2.4.1</version>
           <configuration>
             <!-- do not auto push release commits / tag -->
             <pushChanges>false</pushChanges>

--- a/rcfile/pom.xml
+++ b/rcfile/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.twitter.elephantbird</groupId>
     <artifactId>elephant-bird</artifactId>
-    <version>4.1-SNAPSHOT</version>
+    <version>4.2-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 


### PR DESCRIPTION
Somehow this was missed after the 4.1 release.

I've also updated the version of the maven release plugin which seems to have had some fixes since the version we were using. For one, the release:update-versions command works with this new version of the plugin, when using maven 3.1.0.
