### PR TITLE
Add reporterwrapper to hadoop-compat

### DIFF
--- a/core/src/main/java/com/twitter/elephantbird/mapred/input/DeprecatedInputFormatWrapper.java
+++ b/core/src/main/java/com/twitter/elephantbird/mapred/input/DeprecatedInputFormatWrapper.java
@@ -6,16 +6,15 @@ import java.io.IOException;
 import java.util.List;
 
 import com.twitter.elephantbird.util.HadoopCompat;
+import com.twitter.elephantbird.util.ReporterWrapper;
 import org.apache.hadoop.io.Writable;
 import org.apache.hadoop.io.WritableUtils;
-import org.apache.hadoop.mapred.Counters;
 import org.apache.hadoop.mapred.FileSplit;
 import org.apache.hadoop.mapred.InputSplit;
 import org.apache.hadoop.mapred.JobConf;
 import org.apache.hadoop.mapred.RecordReader;
 import org.apache.hadoop.mapred.Reporter;
 import org.apache.hadoop.mapreduce.InputFormat;
-import org.apache.hadoop.mapreduce.StatusReporter;
 import org.apache.hadoop.mapreduce.TaskAttemptContext;
 import org.apache.hadoop.mapreduce.TaskAttemptID;
 import org.apache.hadoop.util.ReflectionUtils;
@@ -150,57 +149,6 @@ public class DeprecatedInputFormatWrapper<K, V> implements org.apache.hadoop.map
 
     } catch (InterruptedException e) {
       throw new IOException(e);
-    }
-  }
-
-  /**
-   * A reporter that works with both mapred and mapreduce APIs.
-   */
-  private static class ReporterWrapper extends StatusReporter implements Reporter {
-    private Reporter wrappedReporter;
-
-    public ReporterWrapper(Reporter reporter) {
-      wrappedReporter = reporter;
-    }
-
-    @Override
-    public Counters.Counter getCounter(Enum<?> anEnum) {
-      return wrappedReporter.getCounter(anEnum);
-    }
-
-    @Override
-    public Counters.Counter getCounter(String s, String s1) {
-      return wrappedReporter.getCounter(s, s1);
-    }
-
-    @Override
-    public void incrCounter(Enum<?> anEnum, long l) {
-      wrappedReporter.incrCounter(anEnum, l);
-    }
-
-    @Override
-    public void incrCounter(String s, String s1, long l) {
-      wrappedReporter.incrCounter(s, s1, l);
-    }
-
-    @Override
-    public InputSplit getInputSplit() throws UnsupportedOperationException {
-      return wrappedReporter.getInputSplit();
-    }
-
-    @Override
-    public void progress() {
-      wrappedReporter.progress();
-    }
-
-    // @Override
-    public float getProgress() {
-      throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public void setStatus(String s) {
-      wrappedReporter.setStatus(s);
     }
   }
 

--- a/hadoop-compat/src/main/java/com/twitter/elephantbird/util/ReporterWrapper.java
+++ b/hadoop-compat/src/main/java/com/twitter/elephantbird/util/ReporterWrapper.java
@@ -64,7 +64,7 @@ public class ReporterWrapper extends StatusReporter implements Reporter {
     }
 
     public float getProgress() {
-        throw new UnsupportedOperationException();
+        return wrappedReporter.getProgress();
     }
 
     @Override

--- a/hadoop-compat/src/main/java/com/twitter/elephantbird/util/ReporterWrapper.java
+++ b/hadoop-compat/src/main/java/com/twitter/elephantbird/util/ReporterWrapper.java
@@ -24,38 +24,38 @@ import org.apache.hadoop.mapred.Reporter;
 import org.apache.hadoop.mapreduce.StatusReporter;
 
 /**
-* A reporter that works with both mapred and mapreduce APIs.
-*/
+ * A reporter that works with both mapred and mapreduce APIs.
+ */
 public class ReporterWrapper extends StatusReporter implements Reporter {
     private Reporter wrappedReporter;
-    
+
     public ReporterWrapper(Reporter reporter) {
-	wrappedReporter = reporter;
+        wrappedReporter = reporter;
     }
-    
+
     @Override
-	public Counters.Counter getCounter(Enum<?> anEnum) {
-	return wrappedReporter.getCounter(anEnum);
+    public Counters.Counter getCounter(Enum<?> anEnum) {
+        return wrappedReporter.getCounter(anEnum);
     }
-    
+
     @Override
-        public Counters.Counter getCounter(String s, String s1) {
-            return wrappedReporter.getCounter(s, s1);
+    public Counters.Counter getCounter(String s, String s1) {
+        return wrappedReporter.getCounter(s, s1);
     }
-   
+
     @Override
-	public void incrCounter(Enum<?> anEnum, long l) {
-	wrappedReporter.incrCounter(anEnum, l);
+    public void incrCounter(Enum<?> anEnum, long l) {
+        wrappedReporter.incrCounter(anEnum, l);
     }
 
     @Override
     public void incrCounter(String s, String s1, long l) {
-	wrappedReporter.incrCounter(s, s1, l);
+        wrappedReporter.incrCounter(s, s1, l);
     }
-    
+
     @Override
     public InputSplit getInputSplit() throws UnsupportedOperationException {
-	return wrappedReporter.getInputSplit();
+        return wrappedReporter.getInputSplit();
     }
 
     @Override
@@ -64,11 +64,11 @@ public class ReporterWrapper extends StatusReporter implements Reporter {
     }
 
     public float getProgress() {
-	throw new UnsupportedOperationException();
+        throw new UnsupportedOperationException();
     }
 
     @Override
     public void setStatus(String s) {
-            wrappedReporter.setStatus(s);
+        wrappedReporter.setStatus(s);
     }
 }

--- a/hadoop-compat/src/main/java/com/twitter/elephantbird/util/ReporterWrapper.java
+++ b/hadoop-compat/src/main/java/com/twitter/elephantbird/util/ReporterWrapper.java
@@ -1,0 +1,74 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.twitter.elephantbird.util;
+
+import org.apache.hadoop.mapred.Counters;
+import org.apache.hadoop.mapred.InputSplit;
+import org.apache.hadoop.mapred.Reporter;
+import org.apache.hadoop.mapreduce.StatusReporter;
+
+/**
+* A reporter that works with both mapred and mapreduce APIs.
+*/
+public class ReporterWrapper extends StatusReporter implements Reporter {
+    private Reporter wrappedReporter;
+    
+    public ReporterWrapper(Reporter reporter) {
+	wrappedReporter = reporter;
+    }
+    
+    @Override
+	public Counters.Counter getCounter(Enum<?> anEnum) {
+	return wrappedReporter.getCounter(anEnum);
+    }
+    
+    @Override
+        public Counters.Counter getCounter(String s, String s1) {
+            return wrappedReporter.getCounter(s, s1);
+    }
+   
+    @Override
+	public void incrCounter(Enum<?> anEnum, long l) {
+	wrappedReporter.incrCounter(anEnum, l);
+    }
+
+    @Override
+    public void incrCounter(String s, String s1, long l) {
+	wrappedReporter.incrCounter(s, s1, l);
+    }
+    
+    @Override
+    public InputSplit getInputSplit() throws UnsupportedOperationException {
+	return wrappedReporter.getInputSplit();
+    }
+
+    @Override
+    public void progress() {
+        wrappedReporter.progress();
+    }
+
+    public float getProgress() {
+	throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void setStatus(String s) {
+            wrappedReporter.setStatus(s);
+    }
+}


### PR DESCRIPTION
I've been working on hadoop compatibility in Apache Cassandra [1]. I needed a pretty generic reporter. I've seen this code (or similar) in a few other places, and I think it's probably generally applicable to nearly anyone doing similar work. Dmitriy suggested that I submit this upstream.
[1]
https://issues.apache.org/jira/browse/CASSANDRA-5201
