### PR TITLE
Close cloned HDFSIndexInput instances

### DIFF
--- a/lucene/src/main/java/com/twitter/elephantbird/mapreduce/input/LuceneHdfsDirectory.java
+++ b/lucene/src/main/java/com/twitter/elephantbird/mapreduce/input/LuceneHdfsDirectory.java
@@ -93,8 +93,7 @@ public class LuceneHdfsDirectory extends Directory {
     private final FSDataInputStream in;
     private String resourceDescription;
     
-    // Warning: Lucene never closes cloned IndexInputs, it will only do this on the original one. 
-    // The original instance must take care that cloned instances throw AlreadyClosedException when the original one is closed. 
+    // Lucene never closes cloned IndexInputs, it will only do this on the original one. 
     private final List<HDFSIndexInput> clonedList;
     
     protected HDFSIndexInput(String resourceDescription) throws IOException {


### PR DESCRIPTION
When using inside a webapp, there were a lot of open files in (CLOSED_WAIT state) for the index files on HDFS for every request. A lot of open files eventually chokes the host. Also, the FileSystem should not be closed as it is passed from outside and it could be used by others.
