### PR TITLE
Added Support for Handling Invalid JSON Records

### DIFF
--- a/pig/src/main/java/com/twitter/elephantbird/pig/load/JsonLoader.java
+++ b/pig/src/main/java/com/twitter/elephantbird/pig/load/JsonLoader.java
@@ -185,34 +185,27 @@ public class JsonLoader extends LzoBaseLoadFunc {
     } catch (ParseException e) {
       LOG.warn("Could not json-decode string: " + line, e);
       incrCounter(JsonLoaderCounters.LinesParseError, 1L);
-      if (isInvalidRecordEnabled) {
-			retMap.put("error_line", line);
-			retMap.put("error_string", "LinesParseError");
-			return tupleFactory.newTuple(retMap);
-		} else {
-			return null;
-		}
+      return emitErrorTuple(line,"LinesParseError");
     } catch (NumberFormatException e) {
       LOG.warn("Very big number exceeds the scale of long: " + line, e);
       incrCounter(JsonLoaderCounters.LinesParseErrorBadNumber, 1L);
-      if (isInvalidRecordEnabled) {
-			retMap.put("error_line", line);
-			retMap.put("error_string", "LinesParseError");
-			return tupleFactory.newTuple(retMap);
-		} else {
-			return null;
-		}
+      return emitErrorTuple(line,"LinesParseError");
     } catch (ClassCastException e) {
       LOG.warn("Could not convert to Json Object: " + line, e);
       incrCounter(JsonLoaderCounters.LinesParseError, 1L);
-      if (isInvalidRecordEnabled) {
-			retMap.put("error_line", line);
-			retMap.put("error_string", "LinesParseError");
-			return tupleFactory.newTuple(retMap);
-		} else {
-			return null;
-		}
+      return emitErrorTuple(line,"LinesParseError");
     }
+  }
+  
+  private Tuple emitErrorTuple(String error_line,String error_string) {
+    if (isInvalidRecordEnabled){
+	  retMap.put("_error_line", error_line);
+	  retMap.put("_error_string", error_string);
+	  return tupleFactory.newTuple(retMap); 
+    }
+    else{
+      return null;  
+    }	  
   }
 
   private Object wrap(Object value) {

--- a/pig/src/main/java/com/twitter/elephantbird/pig/load/JsonLoader.java
+++ b/pig/src/main/java/com/twitter/elephantbird/pig/load/JsonLoader.java
@@ -2,6 +2,7 @@ package com.twitter.elephantbird.pig.load;
 
 import com.google.common.collect.Maps;
 
+import com.twitter.elephantbird.pig.load.LzoBaseLoadFunc;
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.CommandLineParser;
 import org.apache.commons.cli.GnuParser;
@@ -29,183 +30,237 @@ import java.io.IOException;
 import java.util.Map;
 
 /**
- * Decodes each line as JSON passes the resulting map of values
- * to Pig as a single-element tuple.
+ * Decodes each line as JSON passes the resulting map of values to Pig as a
+ * single-element tuple.
  * 
- * <p>This Loader supports loading of nested JSON structures, but this feature
- * is disabled by default. There are two ways to enable it:<ul>
- * <li>setting the -nestedLoad option in the 
+ * <p>
+ * This Loader supports loading of nested JSON structures, but this feature is
+ * disabled by default. There are two ways to enable it:
+ * <ul>
+ * <li>setting the -nestedLoad option in the
  * {@link JsonLoader#JsonLoader(String)} constructor
- * <li>setting the <code>elephantbird.jsonloader.nestedLoad</code>
- * property to true. This can be done with the following pig command:
- * <pre>grunt> set elephantbird.jsonloader.nestedLoad 'true'</pre>
+ * <li>setting the <code>elephantbird.jsonloader.nestedLoad</code> property to
+ * true. This can be done with the following pig command:
+ * 
+ * <pre>
+ * grunt> set elephantbird.jsonloader.nestedLoad 'true'
+ * </pre>
+ * Added Support for marking JSON record as invalid. This can be filtered on after doing the load
+ * operation. It can be enabled by 
+ * <li>setting the -invalidRecord option in the 
+ * {@link JsonLoader#JsonLoader(String)} constructor
+ * Example: 
+ * <pre>
+ * source_data = LOAD '$input' USING com.intuit.iac.pig.udf.JsonLoader('-nestedLoad -invalidRecord') as (json:map[]);
+ * SPLIT source_data INTO source_data_good_record IF json#'error_string' is null,source_data_bad_record IF json#'error_string' !='';
+ * </pre>
  * </ul>
  */
 public class JsonLoader extends LzoBaseLoadFunc {
-  private static final Logger LOG = LoggerFactory.getLogger(JsonLoader.class);
-  private static final TupleFactory tupleFactory = TupleFactory.getInstance();
-  
-  public static final String NESTED_LOAD_KEY = "elephantbird.jsonloader.nestedLoad";
-  
-  private final static Options validOptions_ = new Options();
-  private final static CommandLineParser parser_ = new GnuParser();
-  private final CommandLine configuredOptions_;
+	private static final Logger LOG = LoggerFactory.getLogger(JsonLoader.class);
+	private static final TupleFactory tupleFactory = TupleFactory.getInstance();
 
-  private final JSONParser jsonParser = new JSONParser();
+	public static final String NESTED_LOAD_KEY = "elephantbird.jsonloader.nestedLoad";
 
-  private enum JsonLoaderCounters {
-    LinesRead,
-    LinesJsonDecoded,
-    LinesParseError,
-    LinesParseErrorBadNumber
-  }
+	private final static Options validOptions_ = new Options();
+	private final static CommandLineParser parser_ = new GnuParser();
+	private final CommandLine configuredOptions_;
 
-  private String inputFormatClassName;
-  private boolean isNestedLoadEnabled = false;
-  
-  private static void populateValidOptions() {
-    validOptions_.addOption("nestedLoad", false, "Enables loading of " +
-        "nested JSON structures");
-    validOptions_.addOption("inputFormat", true, "The input format class name" +
-        " used by this loader instance");
-  }
+	private final JSONParser jsonParser = new JSONParser();
+	private Map<String, Object> retMap;
 
-  public JsonLoader() {
-    // defaults to no options
-    this("");
-  }
+	private enum JsonLoaderCounters {
+		LinesRead, LinesJsonDecoded, LinesParseError, LinesParseErrorBadNumber
+	}
 
-  /**
-   * Constructor. Construct a JsonLoader LoadFunc to load. 
-   * @param inputFormatClassName the inputFormat class name
-   * 
-   * @param optString Loader options. Available options:<ul>
-   * <li>-nestedLoad==(true|false) Enables loading of nested JSON
-   * structures. When enabled, JSON objects are loaded as nested Maps 
-   * and JSON arrays are loaded as Bags.
-   * <li>-inputFormat=className The input format class name used
-   * by this loader instance.
-   * </ul>
-   */
-  public JsonLoader(String optString) {
-    populateValidOptions();
-    String[] optsArr = optString.split(" ");
-    
-    try {
-      configuredOptions_ = parser_.parse(validOptions_, optsArr);
-    } catch (org.apache.commons.cli.ParseException e) {
-        HelpFormatter formatter = new HelpFormatter();
-        formatter.printHelp( "[-nestedLoad] [-inputFormat]", validOptions_ );
-        throw new RuntimeException(e);
-    }
-    isNestedLoadEnabled = configuredOptions_.hasOption("nestedLoad");
-    
-    if (configuredOptions_.getOptionValue("inputFormat") != null) {
-      this.inputFormatClassName = configuredOptions_.getOptionValue("inputFormat");
-    } else {
-      this.inputFormatClassName = TextInputFormat.class.getName();
-    }
-  }
+	private String inputFormatClassName;
+	private boolean isNestedLoadEnabled = false;
+	private boolean isInvalidRecordEnabled = false;
 
-  public void setInputFormatClassName(String inputFormatClassName) {
-    this.inputFormatClassName = inputFormatClassName;
-  }
+	private static void populateValidOptions() {
+		validOptions_.addOption("nestedLoad", false, "Enables loading of "
+				+ "nested JSON structures");
+		validOptions_
+				.addOption("inputFormat", true, "The input format class name"
+						+ " used by this loader instance");
+		validOptions_.addOption("invalidRecord", false,
+				"return invalid record  with keys error_line and error_string");
+	}
 
-  /**
-   * Return every non-null line as a single-element tuple to Pig.
-   */
-  @Override
-  public Tuple getNext() throws IOException {
-    if (reader == null) {
-      return null;
-    }
-    // nested load can be enabled through a pig property
-    if ("true".equals(jobConf.get(NESTED_LOAD_KEY)))
-      isNestedLoadEnabled = true;
-    try {
-      while (reader.nextKeyValue()) {
-        Text value = (Text) reader.getCurrentValue();
-        incrCounter(JsonLoaderCounters.LinesRead, 1L);
-        Tuple t = parseStringToTuple(value.toString());
-        if (t != null) {
-          incrCounter(JsonLoaderCounters.LinesJsonDecoded, 1L);
-          return t;
-        }
-      }
-      return null;
+	public JsonLoader() {
+		// defaults to no options
+		this("");
+	}
 
-    } catch (InterruptedException e) {
-      int errCode = 6018;
-      String errMsg = "Error while reading input";
-      throw new ExecException(errMsg, errCode,
-          PigException.REMOTE_ENVIRONMENT, e);
-    }
-  }
+	/**
+	 * Constructor. Construct a JsonLoader LoadFunc to load.
+	 * 
+	 * @param inputFormatClassName
+	 *            the inputFormat class name
+	 * 
+	 * @param optString
+	 *            Loader options. Available options:
+	 *            <ul>
+	 *            <li>-nestedLoad==(true|false) Enables loading of nested JSON
+	 *            structures. When enabled, JSON objects are loaded as nested
+	 *            Maps and JSON arrays are loaded as Bags.
+	 *            <li>-inputFormat=className The input format class name used by
+	 *            this loader instance.
+	 *            </ul>
+	 */
+	public JsonLoader(String optString) {
+		populateValidOptions();
+		String[] optsArr = optString.split(" ");
 
-  @Override
-  public InputFormat getInputFormat() throws IOException {
-    try {
-      return (FileInputFormat) PigContext.resolveClassName(inputFormatClassName).newInstance();
-    } catch (InstantiationException e) {
-      throw new IOException("Failed creating input format " + inputFormatClassName, e);
-    } catch (IllegalAccessException e) {
-      throw new IOException("Failed creating input format " + inputFormatClassName, e);
-    }
-  }
+		try {
+			configuredOptions_ = parser_.parse(validOptions_, optsArr);
+		} catch (org.apache.commons.cli.ParseException e) {
+			HelpFormatter formatter = new HelpFormatter();
+			formatter.printHelp(
+					"[-nestedLoad] [-inputFormat] [-invalidRecord]",
+					validOptions_);
+			throw new RuntimeException(e);
+		}
+		isNestedLoadEnabled = configuredOptions_.hasOption("nestedLoad");
+		isInvalidRecordEnabled = configuredOptions_.hasOption("invalidRecord");
+		if (isInvalidRecordEnabled) {
+			retMap = Maps.newHashMap();
+		}
+		if (configuredOptions_.getOptionValue("inputFormat") != null) {
+			this.inputFormatClassName = configuredOptions_
+					.getOptionValue("inputFormat");
+		} else {
+			this.inputFormatClassName = TextInputFormat.class.getName();
+		}
+	}
 
-  protected Tuple parseStringToTuple(String line) {
-    try {
-      JSONObject jsonObj = (JSONObject) jsonParser.parse(line);
-      if (jsonObj != null) {
-        return tupleFactory.newTuple(walkJson(jsonObj));
-      } else {
-        // JSONParser#parse(String) may return a null reference, e.g. when
-        // the input parameter is the string "null".  A single line with
-        // "null" is not valid JSON though.
-        LOG.warn("Could not json-decode string: " + line);
-        incrCounter(JsonLoaderCounters.LinesParseError, 1L);
-        return null;
-      }
-    } catch (ParseException e) {
-      LOG.warn("Could not json-decode string: " + line, e);
-      incrCounter(JsonLoaderCounters.LinesParseError, 1L);
-      return null;
-    } catch (NumberFormatException e) {
-      LOG.warn("Very big number exceeds the scale of long: " + line, e);
-      incrCounter(JsonLoaderCounters.LinesParseErrorBadNumber, 1L);
-      return null;
-    } catch (ClassCastException e) {
-      LOG.warn("Could not convert to Json Object: " + line, e);
-      incrCounter(JsonLoaderCounters.LinesParseError, 1L);
-      return null;
-    }
-  }
+	public void setInputFormatClassName(String inputFormatClassName) {
+		this.inputFormatClassName = inputFormatClassName;
+	}
 
-  private Object wrap(Object value) {
-    
-    if (isNestedLoadEnabled && value instanceof JSONObject) {
-      return walkJson((JSONObject) value);
-    }  else if (isNestedLoadEnabled && value instanceof JSONArray) {
-      
-      JSONArray a = (JSONArray) value;
-      DataBag mapValue = new NonSpillableDataBag(a.size());
-      for (int i=0; i<a.size(); i++) {
-        Tuple t = tupleFactory.newTuple(wrap(a.get(i)));
-        mapValue.add(t);
-      }
-      return mapValue;
-      
-    } else {
-      return value != null ? value.toString() : null;
-    }
-  }
+	/**
+	 * Return every non-null line as a single-element tuple to Pig.
+	 */
+	@Override
+	public Tuple getNext() throws IOException {
+		if (reader == null) {
+			return null;
+		}
+		// nested load can be enabled through a pig property
+		if ("true".equals(jobConf.get(NESTED_LOAD_KEY)))
+			isNestedLoadEnabled = true;
+		try {
+			while (reader.nextKeyValue()) {
+				Text value = (Text) reader.getCurrentValue();
+				incrCounter(JsonLoaderCounters.LinesRead, 1L);
+				Tuple t = parseStringToTuple(value.toString());
+				if (t != null) {
+					incrCounter(JsonLoaderCounters.LinesJsonDecoded, 1L);
+					return t;
+				}
+			}
+			return null;
 
-  private Map<String,Object> walkJson(JSONObject jsonObj) {
-    Map<String,Object> v = Maps.newHashMap();
-    for (Object key: jsonObj.keySet()) {
-      v.put(key.toString(), wrap(jsonObj.get(key)));
-    }
-    return v;
-  }
-  
+		} catch (InterruptedException e) {
+			int errCode = 6018;
+			String errMsg = "Error while reading input";
+			throw new ExecException(errMsg, errCode,
+					PigException.REMOTE_ENVIRONMENT, e);
+		}
+	}
+
+	@Override
+	public InputFormat getInputFormat() throws IOException {
+		try {
+			return (FileInputFormat) PigContext.resolveClassName(
+					inputFormatClassName).newInstance();
+		} catch (InstantiationException e) {
+			throw new IOException("Failed creating input format "
+					+ inputFormatClassName, e);
+		} catch (IllegalAccessException e) {
+			throw new IOException("Failed creating input format "
+					+ inputFormatClassName, e);
+		}
+	}
+
+	protected Tuple parseStringToTuple(String line) {
+		try {
+			JSONObject jsonObj = (JSONObject) jsonParser.parse(line);
+			if (jsonObj != null) {
+				return tupleFactory.newTuple(walkJson(jsonObj));
+			} else {
+				// JSONParser#parse(String) may return a null reference, e.g.
+				// when
+				// the input parameter is the string "null". A single line with
+				// "null" is not valid JSON though.
+				if (isInvalidRecordEnabled) {
+					LOG.warn("Could not json-decode string: " + line);
+
+					retMap.put("error_line", line);
+					retMap.put("error_string", "LinesParseError");
+					return tupleFactory.newTuple(retMap);
+				} else {
+					return null;
+				}
+			}
+		} catch (ParseException e) {
+			LOG.warn("Could not json-decode string: " + line, e);
+			incrCounter(JsonLoaderCounters.LinesParseError, 1L);
+			if (isInvalidRecordEnabled) {
+				retMap.put("error_line", line);
+				retMap.put("error_string", "LinesParseError");
+				return tupleFactory.newTuple(retMap);
+			} else {
+				return null;
+			}
+		} catch (NumberFormatException e) {
+			LOG.warn("Very big number exceeds the scale of long: " + line, e);
+			incrCounter(JsonLoaderCounters.LinesParseErrorBadNumber, 1L);
+			if (isInvalidRecordEnabled) {
+				retMap.put("error_line", line);
+				retMap.put("error_string", "LinesParseError");
+				return tupleFactory.newTuple(retMap);
+			} else {
+				return null;
+			}
+		} catch (ClassCastException e) {
+			LOG.warn("Could not convert to Json Object: " + line, e);
+			incrCounter(JsonLoaderCounters.LinesParseError, 1L);
+			if (isInvalidRecordEnabled) {
+				retMap.put("error_line", line);
+				retMap.put("error_string", "LinesParseError");
+				return tupleFactory.newTuple(retMap);
+			} else {
+				return null;
+			}
+		}
+	}
+
+	private Object wrap(Object value) {
+
+		if (isNestedLoadEnabled && value instanceof JSONObject) {
+			return walkJson((JSONObject) value);
+		} else if (isNestedLoadEnabled && value instanceof JSONArray) {
+
+			JSONArray a = (JSONArray) value;
+			DataBag mapValue = new NonSpillableDataBag(a.size());
+			for (int i = 0; i < a.size(); i++) {
+				Tuple t = tupleFactory.newTuple(wrap(a.get(i)));
+				mapValue.add(t);
+			}
+			return mapValue;
+
+		} else {
+			return value != null ? value.toString() : null;
+		}
+	}
+
+	private Map<String, Object> walkJson(JSONObject jsonObj) {
+		Map<String, Object> v = Maps.newHashMap();
+		for (Object key : jsonObj.keySet()) {
+			v.put(key.toString(), wrap(jsonObj.get(key)));
+		}
+		return v;
+	}
+
 }

--- a/pig/src/main/java/com/twitter/elephantbird/pig/load/JsonLoader.java
+++ b/pig/src/main/java/com/twitter/elephantbird/pig/load/JsonLoader.java
@@ -2,7 +2,6 @@ package com.twitter.elephantbird.pig.load;
 
 import com.google.common.collect.Maps;
 
-import com.twitter.elephantbird.pig.load.LzoBaseLoadFunc;
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.CommandLineParser;
 import org.apache.commons.cli.GnuParser;
@@ -30,237 +29,183 @@ import java.io.IOException;
 import java.util.Map;
 
 /**
- * Decodes each line as JSON passes the resulting map of values to Pig as a
- * single-element tuple.
+ * Decodes each line as JSON passes the resulting map of values
+ * to Pig as a single-element tuple.
  * 
- * <p>
- * This Loader supports loading of nested JSON structures, but this feature is
- * disabled by default. There are two ways to enable it:
- * <ul>
- * <li>setting the -nestedLoad option in the
+ * <p>This Loader supports loading of nested JSON structures, but this feature
+ * is disabled by default. There are two ways to enable it:<ul>
+ * <li>setting the -nestedLoad option in the 
  * {@link JsonLoader#JsonLoader(String)} constructor
- * <li>setting the <code>elephantbird.jsonloader.nestedLoad</code> property to
- * true. This can be done with the following pig command:
- * 
- * <pre>
- * grunt> set elephantbird.jsonloader.nestedLoad 'true'
- * </pre>
- * Added Support for marking JSON record as invalid. This can be filtered on after doing the load
- * operation. It can be enabled by 
- * <li>setting the -invalidRecord option in the 
- * {@link JsonLoader#JsonLoader(String)} constructor
- * Example: 
- * <pre>
- * source_data = LOAD '$input' USING com.intuit.iac.pig.udf.JsonLoader('-nestedLoad -invalidRecord') as (json:map[]);
- * SPLIT source_data INTO source_data_good_record IF json#'error_string' is null,source_data_bad_record IF json#'error_string' !='';
- * </pre>
+ * <li>setting the <code>elephantbird.jsonloader.nestedLoad</code>
+ * property to true. This can be done with the following pig command:
+ * <pre>grunt> set elephantbird.jsonloader.nestedLoad 'true'</pre>
  * </ul>
  */
 public class JsonLoader extends LzoBaseLoadFunc {
-	private static final Logger LOG = LoggerFactory.getLogger(JsonLoader.class);
-	private static final TupleFactory tupleFactory = TupleFactory.getInstance();
+  private static final Logger LOG = LoggerFactory.getLogger(JsonLoader.class);
+  private static final TupleFactory tupleFactory = TupleFactory.getInstance();
+  
+  public static final String NESTED_LOAD_KEY = "elephantbird.jsonloader.nestedLoad";
+  
+  private final static Options validOptions_ = new Options();
+  private final static CommandLineParser parser_ = new GnuParser();
+  private final CommandLine configuredOptions_;
 
-	public static final String NESTED_LOAD_KEY = "elephantbird.jsonloader.nestedLoad";
+  private final JSONParser jsonParser = new JSONParser();
 
-	private final static Options validOptions_ = new Options();
-	private final static CommandLineParser parser_ = new GnuParser();
-	private final CommandLine configuredOptions_;
+  private enum JsonLoaderCounters {
+    LinesRead,
+    LinesJsonDecoded,
+    LinesParseError,
+    LinesParseErrorBadNumber
+  }
 
-	private final JSONParser jsonParser = new JSONParser();
-	private Map<String, Object> retMap;
+  private String inputFormatClassName;
+  private boolean isNestedLoadEnabled = false;
+  
+  private static void populateValidOptions() {
+    validOptions_.addOption("nestedLoad", false, "Enables loading of " +
+        "nested JSON structures");
+    validOptions_.addOption("inputFormat", true, "The input format class name" +
+        " used by this loader instance");
+  }
 
-	private enum JsonLoaderCounters {
-		LinesRead, LinesJsonDecoded, LinesParseError, LinesParseErrorBadNumber
-	}
+  public JsonLoader() {
+    // defaults to no options
+    this("");
+  }
 
-	private String inputFormatClassName;
-	private boolean isNestedLoadEnabled = false;
-	private boolean isInvalidRecordEnabled = false;
+  /**
+   * Constructor. Construct a JsonLoader LoadFunc to load. 
+   * @param inputFormatClassName the inputFormat class name
+   * 
+   * @param optString Loader options. Available options:<ul>
+   * <li>-nestedLoad==(true|false) Enables loading of nested JSON
+   * structures. When enabled, JSON objects are loaded as nested Maps 
+   * and JSON arrays are loaded as Bags.
+   * <li>-inputFormat=className The input format class name used
+   * by this loader instance.
+   * </ul>
+   */
+  public JsonLoader(String optString) {
+    populateValidOptions();
+    String[] optsArr = optString.split(" ");
+    
+    try {
+      configuredOptions_ = parser_.parse(validOptions_, optsArr);
+    } catch (org.apache.commons.cli.ParseException e) {
+        HelpFormatter formatter = new HelpFormatter();
+        formatter.printHelp( "[-nestedLoad] [-inputFormat]", validOptions_ );
+        throw new RuntimeException(e);
+    }
+    isNestedLoadEnabled = configuredOptions_.hasOption("nestedLoad");
+    
+    if (configuredOptions_.getOptionValue("inputFormat") != null) {
+      this.inputFormatClassName = configuredOptions_.getOptionValue("inputFormat");
+    } else {
+      this.inputFormatClassName = TextInputFormat.class.getName();
+    }
+  }
 
-	private static void populateValidOptions() {
-		validOptions_.addOption("nestedLoad", false, "Enables loading of "
-				+ "nested JSON structures");
-		validOptions_
-				.addOption("inputFormat", true, "The input format class name"
-						+ " used by this loader instance");
-		validOptions_.addOption("invalidRecord", false,
-				"return invalid record  with keys error_line and error_string");
-	}
+  public void setInputFormatClassName(String inputFormatClassName) {
+    this.inputFormatClassName = inputFormatClassName;
+  }
 
-	public JsonLoader() {
-		// defaults to no options
-		this("");
-	}
+  /**
+   * Return every non-null line as a single-element tuple to Pig.
+   */
+  @Override
+  public Tuple getNext() throws IOException {
+    if (reader == null) {
+      return null;
+    }
+    // nested load can be enabled through a pig property
+    if ("true".equals(jobConf.get(NESTED_LOAD_KEY)))
+      isNestedLoadEnabled = true;
+    try {
+      while (reader.nextKeyValue()) {
+        Text value = (Text) reader.getCurrentValue();
+        incrCounter(JsonLoaderCounters.LinesRead, 1L);
+        Tuple t = parseStringToTuple(value.toString());
+        if (t != null) {
+          incrCounter(JsonLoaderCounters.LinesJsonDecoded, 1L);
+          return t;
+        }
+      }
+      return null;
 
-	/**
-	 * Constructor. Construct a JsonLoader LoadFunc to load.
-	 * 
-	 * @param inputFormatClassName
-	 *            the inputFormat class name
-	 * 
-	 * @param optString
-	 *            Loader options. Available options:
-	 *            <ul>
-	 *            <li>-nestedLoad==(true|false) Enables loading of nested JSON
-	 *            structures. When enabled, JSON objects are loaded as nested
-	 *            Maps and JSON arrays are loaded as Bags.
-	 *            <li>-inputFormat=className The input format class name used by
-	 *            this loader instance.
-	 *            </ul>
-	 */
-	public JsonLoader(String optString) {
-		populateValidOptions();
-		String[] optsArr = optString.split(" ");
+    } catch (InterruptedException e) {
+      int errCode = 6018;
+      String errMsg = "Error while reading input";
+      throw new ExecException(errMsg, errCode,
+          PigException.REMOTE_ENVIRONMENT, e);
+    }
+  }
 
-		try {
-			configuredOptions_ = parser_.parse(validOptions_, optsArr);
-		} catch (org.apache.commons.cli.ParseException e) {
-			HelpFormatter formatter = new HelpFormatter();
-			formatter.printHelp(
-					"[-nestedLoad] [-inputFormat] [-invalidRecord]",
-					validOptions_);
-			throw new RuntimeException(e);
-		}
-		isNestedLoadEnabled = configuredOptions_.hasOption("nestedLoad");
-		isInvalidRecordEnabled = configuredOptions_.hasOption("invalidRecord");
-		if (isInvalidRecordEnabled) {
-			retMap = Maps.newHashMap();
-		}
-		if (configuredOptions_.getOptionValue("inputFormat") != null) {
-			this.inputFormatClassName = configuredOptions_
-					.getOptionValue("inputFormat");
-		} else {
-			this.inputFormatClassName = TextInputFormat.class.getName();
-		}
-	}
+  @Override
+  public InputFormat getInputFormat() throws IOException {
+    try {
+      return (FileInputFormat) PigContext.resolveClassName(inputFormatClassName).newInstance();
+    } catch (InstantiationException e) {
+      throw new IOException("Failed creating input format " + inputFormatClassName, e);
+    } catch (IllegalAccessException e) {
+      throw new IOException("Failed creating input format " + inputFormatClassName, e);
+    }
+  }
 
-	public void setInputFormatClassName(String inputFormatClassName) {
-		this.inputFormatClassName = inputFormatClassName;
-	}
+  protected Tuple parseStringToTuple(String line) {
+    try {
+      JSONObject jsonObj = (JSONObject) jsonParser.parse(line);
+      if (jsonObj != null) {
+        return tupleFactory.newTuple(walkJson(jsonObj));
+      } else {
+        // JSONParser#parse(String) may return a null reference, e.g. when
+        // the input parameter is the string "null".  A single line with
+        // "null" is not valid JSON though.
+        LOG.warn("Could not json-decode string: " + line);
+        incrCounter(JsonLoaderCounters.LinesParseError, 1L);
+        return null;
+      }
+    } catch (ParseException e) {
+      LOG.warn("Could not json-decode string: " + line, e);
+      incrCounter(JsonLoaderCounters.LinesParseError, 1L);
+      return null;
+    } catch (NumberFormatException e) {
+      LOG.warn("Very big number exceeds the scale of long: " + line, e);
+      incrCounter(JsonLoaderCounters.LinesParseErrorBadNumber, 1L);
+      return null;
+    } catch (ClassCastException e) {
+      LOG.warn("Could not convert to Json Object: " + line, e);
+      incrCounter(JsonLoaderCounters.LinesParseError, 1L);
+      return null;
+    }
+  }
 
-	/**
-	 * Return every non-null line as a single-element tuple to Pig.
-	 */
-	@Override
-	public Tuple getNext() throws IOException {
-		if (reader == null) {
-			return null;
-		}
-		// nested load can be enabled through a pig property
-		if ("true".equals(jobConf.get(NESTED_LOAD_KEY)))
-			isNestedLoadEnabled = true;
-		try {
-			while (reader.nextKeyValue()) {
-				Text value = (Text) reader.getCurrentValue();
-				incrCounter(JsonLoaderCounters.LinesRead, 1L);
-				Tuple t = parseStringToTuple(value.toString());
-				if (t != null) {
-					incrCounter(JsonLoaderCounters.LinesJsonDecoded, 1L);
-					return t;
-				}
-			}
-			return null;
+  private Object wrap(Object value) {
+    
+    if (isNestedLoadEnabled && value instanceof JSONObject) {
+      return walkJson((JSONObject) value);
+    }  else if (isNestedLoadEnabled && value instanceof JSONArray) {
+      
+      JSONArray a = (JSONArray) value;
+      DataBag mapValue = new NonSpillableDataBag(a.size());
+      for (int i=0; i<a.size(); i++) {
+        Tuple t = tupleFactory.newTuple(wrap(a.get(i)));
+        mapValue.add(t);
+      }
+      return mapValue;
+      
+    } else {
+      return value != null ? value.toString() : null;
+    }
+  }
 
-		} catch (InterruptedException e) {
-			int errCode = 6018;
-			String errMsg = "Error while reading input";
-			throw new ExecException(errMsg, errCode,
-					PigException.REMOTE_ENVIRONMENT, e);
-		}
-	}
-
-	@Override
-	public InputFormat getInputFormat() throws IOException {
-		try {
-			return (FileInputFormat) PigContext.resolveClassName(
-					inputFormatClassName).newInstance();
-		} catch (InstantiationException e) {
-			throw new IOException("Failed creating input format "
-					+ inputFormatClassName, e);
-		} catch (IllegalAccessException e) {
-			throw new IOException("Failed creating input format "
-					+ inputFormatClassName, e);
-		}
-	}
-
-	protected Tuple parseStringToTuple(String line) {
-		try {
-			JSONObject jsonObj = (JSONObject) jsonParser.parse(line);
-			if (jsonObj != null) {
-				return tupleFactory.newTuple(walkJson(jsonObj));
-			} else {
-				// JSONParser#parse(String) may return a null reference, e.g.
-				// when
-				// the input parameter is the string "null". A single line with
-				// "null" is not valid JSON though.
-				if (isInvalidRecordEnabled) {
-					LOG.warn("Could not json-decode string: " + line);
-
-					retMap.put("error_line", line);
-					retMap.put("error_string", "LinesParseError");
-					return tupleFactory.newTuple(retMap);
-				} else {
-					return null;
-				}
-			}
-		} catch (ParseException e) {
-			LOG.warn("Could not json-decode string: " + line, e);
-			incrCounter(JsonLoaderCounters.LinesParseError, 1L);
-			if (isInvalidRecordEnabled) {
-				retMap.put("error_line", line);
-				retMap.put("error_string", "LinesParseError");
-				return tupleFactory.newTuple(retMap);
-			} else {
-				return null;
-			}
-		} catch (NumberFormatException e) {
-			LOG.warn("Very big number exceeds the scale of long: " + line, e);
-			incrCounter(JsonLoaderCounters.LinesParseErrorBadNumber, 1L);
-			if (isInvalidRecordEnabled) {
-				retMap.put("error_line", line);
-				retMap.put("error_string", "LinesParseError");
-				return tupleFactory.newTuple(retMap);
-			} else {
-				return null;
-			}
-		} catch (ClassCastException e) {
-			LOG.warn("Could not convert to Json Object: " + line, e);
-			incrCounter(JsonLoaderCounters.LinesParseError, 1L);
-			if (isInvalidRecordEnabled) {
-				retMap.put("error_line", line);
-				retMap.put("error_string", "LinesParseError");
-				return tupleFactory.newTuple(retMap);
-			} else {
-				return null;
-			}
-		}
-	}
-
-	private Object wrap(Object value) {
-
-		if (isNestedLoadEnabled && value instanceof JSONObject) {
-			return walkJson((JSONObject) value);
-		} else if (isNestedLoadEnabled && value instanceof JSONArray) {
-
-			JSONArray a = (JSONArray) value;
-			DataBag mapValue = new NonSpillableDataBag(a.size());
-			for (int i = 0; i < a.size(); i++) {
-				Tuple t = tupleFactory.newTuple(wrap(a.get(i)));
-				mapValue.add(t);
-			}
-			return mapValue;
-
-		} else {
-			return value != null ? value.toString() : null;
-		}
-	}
-
-	private Map<String, Object> walkJson(JSONObject jsonObj) {
-		Map<String, Object> v = Maps.newHashMap();
-		for (Object key : jsonObj.keySet()) {
-			v.put(key.toString(), wrap(jsonObj.get(key)));
-		}
-		return v;
-	}
-
+  private Map<String,Object> walkJson(JSONObject jsonObj) {
+    Map<String,Object> v = Maps.newHashMap();
+    for (Object key: jsonObj.keySet()) {
+      v.put(key.toString(), wrap(jsonObj.get(key)));
+    }
+    return v;
+  }
+  
 }

--- a/pig/src/test/java/com/twitter/elephantbird/pig/load/TestJsonLoader.java
+++ b/pig/src/test/java/com/twitter/elephantbird/pig/load/TestJsonLoader.java
@@ -151,32 +151,31 @@ public class TestJsonLoader {
   }
   @Test
   public void testInValidRecord() throws IOException {
-	    
-	    File tempFile = File.createTempFile("json", null);
-	    tempFile.deleteOnExit();
+    File tempFile = File.createTempFile("json", null);
+	tempFile.deleteOnExit();
 
-	    FileWriter writer = new FileWriter(tempFile);
-	    String json = "{\"a\": 3,\"b\": 1}"
+	FileWriter writer = new FileWriter(tempFile);
+	String json = "{\"a\": 3,\"b\": 1}"
 	    		      + "{\"a\"= 3,\"b\": 1}";
-	    writer.write(json);
-	    writer.close();
+	writer.write(json);
+	writer.close();
 
 	    // extract hashtags from it
-	    PigServer pigServer = PigTestUtil.makePigServer();
-	    logAndRegisterQuery(pigServer, "data = load '" + tempFile.getAbsolutePath()
+	PigServer pigServer = PigTestUtil.makePigServer();
+	logAndRegisterQuery(pigServer, "data = load '" + tempFile.getAbsolutePath()
 	        + "' using com.twitter.elephantbird.pig.load.JsonLoader('-invalidRecord') as (json: map[]);");
-	    logAndRegisterQuery(pigServer, "split data into good_data IF json#'_error_string' is null,bad_data IF json#'_error_string' !='';");
-	    Iterator<Tuple> tuples = pigServer.openIterator("bad_data");
+	logAndRegisterQuery(pigServer, "split data into good_data IF json#'_error_string' is null,bad_data IF json#'_error_string' !='';");
+	Iterator<Tuple> tuples = pigServer.openIterator("bad_data");
 
-	    int count = 0;
-	    while(tuples.hasNext()) {
-	      Tuple t = tuples.next();
-	      Assert.assertEquals(HashMap.class, t.get(0).getClass());
-	      count++;
-	    }
+	int count = 0;
+	while(tuples.hasNext()) {
+      Tuple t = tuples.next();
+	  Assert.assertEquals(HashMap.class, t.get(0).getClass());
+	  count++;
+    }
 	    
-	    Assert.assertEquals(1, count); // expect one tuple
-	  }
+	Assert.assertEquals(1, count); // expect one tuple
+  }
 
   private void logAndRegisterQuery(PigServer pigServer, String query) throws IOException {
     LOG.info("Registering query: " + query);

--- a/pig/src/test/java/com/twitter/elephantbird/pig/load/TestJsonLoader.java
+++ b/pig/src/test/java/com/twitter/elephantbird/pig/load/TestJsonLoader.java
@@ -165,7 +165,7 @@ public class TestJsonLoader {
 	    PigServer pigServer = PigTestUtil.makePigServer();
 	    logAndRegisterQuery(pigServer, "data = load '" + tempFile.getAbsolutePath()
 	        + "' using com.twitter.elephantbird.pig.load.JsonLoader('-invalidRecord') as (json: map[]);");
-	    logAndRegisterQuery(pigServer, "split data into good_data IF json#'error_string' is null,bad_data IF json#'error_string' !='';");
+	    logAndRegisterQuery(pigServer, "split data into good_data IF json#'_error_string' is null,bad_data IF json#'_error_string' !='';");
 	    Iterator<Tuple> tuples = pigServer.openIterator("bad_data");
 
 	    int count = 0;

--- a/pig/src/test/java/com/twitter/elephantbird/pig/load/TestJsonLoader.java
+++ b/pig/src/test/java/com/twitter/elephantbird/pig/load/TestJsonLoader.java
@@ -1,6 +1,7 @@
 package com.twitter.elephantbird.pig.load;
 
 import com.twitter.elephantbird.pig.util.PigTestUtil;
+
 import org.apache.pig.PigServer;
 import org.apache.pig.data.Tuple;
 import org.json.simple.parser.JSONParser;
@@ -12,6 +13,7 @@ import org.slf4j.LoggerFactory;
 import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
+import java.util.HashMap;
 import java.util.Iterator;
 
 /**
@@ -147,6 +149,34 @@ public class TestJsonLoader {
     
     Assert.assertEquals(1, count); // expect one tuple
   }
+  @Test
+  public void testInValidRecord() throws IOException {
+	    
+	    File tempFile = File.createTempFile("json", null);
+	    tempFile.deleteOnExit();
+
+	    FileWriter writer = new FileWriter(tempFile);
+	    String json = "{\"a\": 3,\"b\": 1}"
+	    		      + "{\"a\"= 3,\"b\": 1}";
+	    writer.write(json);
+	    writer.close();
+
+	    // extract hashtags from it
+	    PigServer pigServer = PigTestUtil.makePigServer();
+	    logAndRegisterQuery(pigServer, "data = load '" + tempFile.getAbsolutePath()
+	        + "' using com.twitter.elephantbird.pig.load.JsonLoader('-invalidRecord') as (json: map[]);");
+	    logAndRegisterQuery(pigServer, "split data into good_data IF json#'error_string' is null,bad_data IF json#'error_string' !='';");
+	    Iterator<Tuple> tuples = pigServer.openIterator("bad_data");
+
+	    int count = 0;
+	    while(tuples.hasNext()) {
+	      Tuple t = tuples.next();
+	      Assert.assertEquals(HashMap.class, t.get(0).getClass());
+	      count++;
+	    }
+	    
+	    Assert.assertEquals(1, count); // expect one tuple
+	  }
 
   private void logAndRegisterQuery(PigServer pigServer, String query) throws IOException {
     LOG.info("Registering query: " + query);


### PR DESCRIPTION
Hi Kevin,

I have added support for handling Invalid JSON Records. Currently It just filters out invalid JSON Records. I have added support to return invalid records which can be segregated into good and bad records. This can help if we want to report invalid records to the upstream user who is generating the records.

This can be changed by setting the -invalidRecord option in the JsonLoader constructor
 Example: 
source_data = LOAD '$input' USING com.intuit.iac.pig.udf.JsonLoader('-nestedLoad -invalidRecord') as (json:map[]);
SPLIT source_data INTO source_data_good_record IF json#'error_string' is null,source_data_bad_record IF json#'error_string' !='';
