### PR TITLE
Correct an issue parsing bytes field from protobuf

### DIFF
--- a/hive/src/main/java/com/twitter/elephantbird/hive/serde/ProtobufStructObjectInspector.java
+++ b/hive/src/main/java/com/twitter/elephantbird/hive/serde/ProtobufStructObjectInspector.java
@@ -159,6 +159,9 @@ public final class ProtobufStructObjectInspector extends SettableStructObjectIns
     if (fieldDescriptor.getType() == Type.ENUM) {
       return ((EnumValueDescriptor)result).getName();
     }
+    if (fieldDescriptor.getType() == Type.BYTES && (result instanceof ByteString)) {
+      return ((ByteString)result).toByteArray();
+    }
     return result;
   }
 


### PR DESCRIPTION
com.google.protobuf.ByteString doesn't provide an implicit conversion to a Binary primitive, so the above change is necessary to detect ByteString, convert to byte[], and return that.
