### PR TITLE
support the --java:bean thrift compiler flag

### DIFF
--- a/core/src/main/java/com/twitter/elephantbird/util/ThriftUtils.java
+++ b/core/src/main/java/com/twitter/elephantbird/util/ThriftUtils.java
@@ -145,7 +145,7 @@ public class ThriftUtils {
       }
     }
 
-    // look for bean style accessors
+    // look for bean style accessors get_fieldName and is_fieldName
 
     for(String prefix : new String[]{"get_", "is_"}) {
       try {


### PR DESCRIPTION
the java:bean flag changes the name of the accessor methods ThriftUtils was only looking for the default accessor method names (get_fieldname vs getFieldname). This PR adds support for both styles. 
