### PR TITLE
Set the configuration to the real input split instantiated in DeprecatedInputFormatWrapper

### DIFF
--- a/core/src/main/java/com/twitter/elephantbird/mapred/input/DeprecatedInputFormatWrapper.java
+++ b/core/src/main/java/com/twitter/elephantbird/mapred/input/DeprecatedInputFormatWrapper.java
@@ -6,6 +6,7 @@ import java.io.IOException;
 import java.util.List;
 
 import com.twitter.elephantbird.util.HadoopCompat;
+import org.apache.hadoop.conf.Configured;
 import org.apache.hadoop.io.Writable;
 import org.apache.hadoop.io.WritableUtils;
 import org.apache.hadoop.mapred.Counters;
@@ -142,7 +143,7 @@ public class DeprecatedInputFormatWrapper<K, V> implements org.apache.hadoop.map
               mapreduceFileSplit.getLength(),
               mapreduceFileSplit.getLocations());
         } else {
-          resultSplits[i++] = new InputSplitWrapper(split);
+          resultSplits[i++] = new InputSplitWrapper(split, job);
         }
       }
 
@@ -362,7 +363,7 @@ public class DeprecatedInputFormatWrapper<K, V> implements org.apache.hadoop.map
     }
   }
 
-  private static class InputSplitWrapper implements InputSplit {
+  private static class InputSplitWrapper extends Configured implements InputSplit {
 
     org.apache.hadoop.mapreduce.InputSplit realSplit;
 
@@ -372,6 +373,11 @@ public class DeprecatedInputFormatWrapper<K, V> implements org.apache.hadoop.map
 
     public InputSplitWrapper(org.apache.hadoop.mapreduce.InputSplit realSplit) {
       this.realSplit = realSplit;
+    }
+
+    public InputSplitWrapper(org.apache.hadoop.mapreduce.InputSplit realSplit, JobConf job) {
+      this.realSplit = realSplit;
+      this.setConf(job);
     }
 
     @Override
@@ -404,7 +410,7 @@ public class DeprecatedInputFormatWrapper<K, V> implements org.apache.hadoop.map
       }
 
       realSplit = (org.apache.hadoop.mapreduce.InputSplit)
-                  ReflectionUtils.newInstance(splitClass, null);
+                  ReflectionUtils.newInstance(splitClass, this.getConf());
       ((Writable)realSplit).readFields(in);
     }
 


### PR DESCRIPTION
Greetings,

please, consider pulling this modifications.

Updated `DeprecatedInputFormatWrapper#getSplits(JobConf, int)` to instantiate `InputSplitWrapper` passing the JobConf configuration.
Updated `InputSplitWrapper` to be configurable.

This changes will allow the real input split to get the configuration from the front when instantiated.

Recently I have started to test Cascading in local and cluster mode and I have been trying to launch flows conveying the configuration files in the .jar (core-site.xml, mapred-site.xml, hbase-site.xml, etc...) and not conveying the configuration files (configuration set in code).

I found that my InputSplits were not receiving the configuration from the front, because `DeprecatedInputFormatWrapper$InputSplitWrapper` was filtering it. The solution shown here is define the InputSplitWrapper as Configurable (we don't lose anything ;) and set the configuration at instantiation time.

I need this to create a GoraTap for Cascading.
Bugs related: https://github.com/cwensel/cascading/pull/29
