### PR TITLE
Add support for strict mode in LzoTextDelimited

### DIFF
--- a/cascading2/src/main/java/com/twitter/elephantbird/cascading2/scheme/LzoTextDelimited.java
+++ b/cascading2/src/main/java/com/twitter/elephantbird/cascading2/scheme/LzoTextDelimited.java
@@ -51,7 +51,8 @@ public class LzoTextDelimited extends TextDelimited {
 
   public LzoTextDelimited(Fields fields, boolean skipHeader, boolean writeHeader, String delimiter,
     boolean strict, String quote, Class[] types, boolean safe) {
-    super(fields, skipHeader, writeHeader, delimiter, strict, quote,  types, safe);
+    // We set Compress to null as this class's point is to explicitly handle this
+    super(fields, null, skipHeader, writeHeader, delimiter, strict, quote, types, safe);
   }
 
   public LzoTextDelimited(Fields fields, boolean skipHeader, String delimiter,


### PR DESCRIPTION
We already support the constructor for safe in cascading's TextDelimited in LzoTextDelimited, but we can additionally support strict mode.

Closes https://github.com/kevinweil/elephant-bird/issues/350
Relates to https://github.com/twitter/scalding/issues/677

One thing to note is that none of the other constructors have the writeHeader, but since the convention seems to be to just proxy straight to the TextDelimiter constructor I kept this. We could drop it and set a default.
