### PR TITLE
SequenceFileLoader/Writer Unable to Recognize -c Parameter in commons-cli 1.0

### DIFF
--- a/pig/src/main/java/com/twitter/elephantbird/pig/store/SequenceFileStorage.java
+++ b/pig/src/main/java/com/twitter/elephantbird/pig/store/SequenceFileStorage.java
@@ -80,7 +80,7 @@ public class SequenceFileStorage<K extends Writable, V extends Writable> extends
    * Refinement of {@link SequenceFileConfig} which adds key/value "type" option.
    */
   private class Config extends SequenceFileConfig<K, V> {
-    public static final char TYPE_PARAM_SHORT = 't';
+    public static final String TYPE_PARAM_SHORT = "t";
     public static final String TYPE_PARAM = "type";
     public Class<K> keyClass;
     public Class<V> valueClass;

--- a/pig/src/main/java/com/twitter/elephantbird/pig/store/SequenceFileStorage.java
+++ b/pig/src/main/java/com/twitter/elephantbird/pig/store/SequenceFileStorage.java
@@ -80,6 +80,7 @@ public class SequenceFileStorage<K extends Writable, V extends Writable> extends
    * Refinement of {@link SequenceFileConfig} which adds key/value "type" option.
    */
   private class Config extends SequenceFileConfig<K, V> {
+    public static final char TYPE_PARAM_SHORT = 't';
     public static final String TYPE_PARAM = "type";
     public Class<K> keyClass;
     public Class<V> valueClass;
@@ -99,7 +100,7 @@ public class SequenceFileStorage<K extends Writable, V extends Writable> extends
               .withArgName("cls")
               .withDescription(
                   "Writable type of data. Defaults to type returned by getWritableClass()"
-                      + " method of configured WritableConverter.").create("t");
+                      + " method of configured WritableConverter.").create(TYPE_PARAM_SHORT);
       return super.getKeyValueOptions().addOption(typeOption);
     }
 
@@ -109,8 +110,8 @@ public class SequenceFileStorage<K extends Writable, V extends Writable> extends
        * Attempt to initialize key, value classes using arguments. If user doesn't specify '--type'
        * arg, then class will be null.
        */
-      keyClass = getWritableClass(keyArguments.getOptionValue(TYPE_PARAM));
-      valueClass = getWritableClass(valueArguments.getOptionValue(TYPE_PARAM));
+      keyClass = getWritableClass(keyArguments.getOptionValue(TYPE_PARAM_SHORT));
+      valueClass = getWritableClass(valueArguments.getOptionValue(TYPE_PARAM_SHORT));
 
       // initialize key, value converters
       keyConverter.initialize(keyClass);

--- a/pig/src/main/java/com/twitter/elephantbird/pig/util/SequenceFileConfig.java
+++ b/pig/src/main/java/com/twitter/elephantbird/pig/util/SequenceFileConfig.java
@@ -31,7 +31,7 @@ import com.twitter.elephantbird.pig.store.SequenceFileStorage;
  * @see WritableConverter
  */
 public class SequenceFileConfig<K extends Writable, V extends Writable> {
-  public static final Char CONVERTER_PARAM_SHORT = 'c';
+  public static final String CONVERTER_PARAM_SHORT = "c";
   public static final String CONVERTER_PARAM = "converter";
   public final CommandLine keyArguments;
   public final CommandLine valueArguments;

--- a/pig/src/main/java/com/twitter/elephantbird/pig/util/SequenceFileConfig.java
+++ b/pig/src/main/java/com/twitter/elephantbird/pig/util/SequenceFileConfig.java
@@ -31,6 +31,7 @@ import com.twitter.elephantbird.pig.store.SequenceFileStorage;
  * @see WritableConverter
  */
 public class SequenceFileConfig<K extends Writable, V extends Writable> {
+  public static final Char CONVERTER_PARAM_SHORT = 'c';
   public static final String CONVERTER_PARAM = "converter";
   public final CommandLine keyArguments;
   public final CommandLine valueArguments;
@@ -137,7 +138,7 @@ public class SequenceFileConfig<K extends Writable, V extends Writable> {
             .withArgName("cls")
             .withDescription(
                 String.format("Converter type to use for conversion of data. Defaults to '%s'.",
-                    TextConverter.class.getName())).create("c");
+                    TextConverter.class.getName())).create(CONVERTER_PARAM_SHORT);
     return new Options().addOption(converterOption);
   }
 
@@ -178,7 +179,7 @@ public class SequenceFileConfig<K extends Writable, V extends Writable> {
 
       // get converter classname
       String converterClassName =
-          arguments.getOptionValue(CONVERTER_PARAM, TextConverter.class.getName());
+          arguments.getOptionValue(CONVERTER_PARAM_SHORT, TextConverter.class.getName());
 
       // get converter class
       Class<WritableConverter<T>> converterClass =


### PR DESCRIPTION
While the elephant-bird specifies commons-cli 1.2 in the pom.xml, currently Pig compiles with commons-cli 1.0 by default. In my case, 1.0 was unluckily picked up while running the following script and caused the error message.

The reason was that in commons-cli 1.0, longOpt is assumed to contain the leading"--" while it's not so in 1.2. (The way values are retrieved are slightly different) Fortunately, both versions agree the shortOpt (the option name) do contain any hyphens. So the code can be made backward compatible by using shortOpt 'c' and 't' to getOptionValue in SequenceFileConfig and Writer.


To (hopefully) replicate, have common-clis 1.0 on your classpath, and run
```
raw_data = load 'INPUT' using com.twitter.elephantbird.pig.load.SequenceFileLoader (
    '-c com.twitter.elephantbird.pig.util.NullWritableConverter',
    '-c com.twitter.elephantbird.pig.util.ProtobufWritableConverter com.twitter.elephantbird.examples.proto.AddressBookProtos.Person'
);

dump raw_data;
```
The script fails with
> <file D:\GitHub\elephant-bird\examples\src\main\pig\people_phone_number_count.pig, line 15, column 11> pig script failed to validate: java.lang.RuntimeException: could not instantiate 'com.twitter.elephantbird.pig.load.SequenceFileLoader' with arguments '[-c com.twitter.elephantbird.pig.util.NullWritableConverter, -c com.twitter.elephantbird.pig.util.ProtobufWritableConverter com.twitter.elephantbird.examples.proto.AddressBookProtos.Person]'
    at org.apache.pig.parser.QueryParserDriver.parse(QueryParserDriver.java:196)
    at org.apache.pig.PigServer$Graph.parseQuery(PigServer.java:1722)
    at org.apache.pig.PigServer$Graph.access$000(PigServer.java:1430)
    at org.apache.pig.PigServer.parseAndBuild(PigServer.java:381)
    at org.apache.pig.PigServer.executeBatch(PigServer.java:406)
    at org.apache.pig.PigServer.executeBatch(PigServer.java:392)
    at org.apache.pig.tools.grunt.GruntParser.executeBatch(GruntParser.java:170)
    at org.apache.pig.tools.grunt.GruntParser.processDump(GruntParser.java:747)
    at org.apache.pig.tools.pigscript.parser.PigScriptParser.parse(PigScriptParser.java:372)
    at org.apache.pig.tools.grunt.GruntParser.parseStopOnError(GruntParser.java:228)
    at org.apache.pig.tools.grunt.GruntParser.parseStopOnError(GruntParser.java:203)
    at org.apache.pig.tools.grunt.Grunt.exec(Grunt.java:81)
    at org.apache.pig.Main.run(Main.java:608)
    at org.apache.pig.Main.main(Main.java:156)
Caused by: 
<file D:\GitHub\elephant-bird\examples\src\main\pig\people_phone_number_count.pig, line 15, column 11> pig script failed to validate: java.lang.RuntimeException: could not instantiate 'com.twitter.elephantbird.pig.load.SequenceFileLoader' with arguments '[-c com.twitter.elephantbird.pig.util.NullWritableConverter, -c com.twitter.elephantbird.pig.util.ProtobufWritableConverter com.twitter.elephantbird.examples.proto.AddressBookProtos.Person]'
    at org.apache.pig.parser.LogicalPlanBuilder.buildLoadOp(LogicalPlanBuilder.java:881)
    at org.apache.pig.parser.LogicalPlanGenerator.load_clause(LogicalPlanGenerator.java:3568)
    at org.apache.pig.parser.LogicalPlanGenerator.op_clause(LogicalPlanGenerator.java:1625)
    at org.apache.pig.parser.LogicalPlanGenerator.general_statement(LogicalPlanGenerator.java:1102)
    at org.apache.pig.parser.LogicalPlanGenerator.statement(LogicalPlanGenerator.java:560)
    at org.apache.pig.parser.LogicalPlanGenerator.query(LogicalPlanGenerator.java:421)
    at org.apache.pig.parser.QueryParserDriver.parse(QueryParserDriver.java:188)
    ... 13 more
Caused by: java.lang.RuntimeException: could not instantiate 'com.twitter.elephantbird.pig.load.SequenceFileLoader' with arguments '[-c com.twitter.elephantbird.pig.util.NullWritableConverter, -c com.twitter.elephantbird.pig.util.ProtobufWritableConverter com.twitter.elephantbird.examples.proto.AddressBookProtos.Person]'
    at org.apache.pig.impl.PigContext.instantiateFuncFromSpec(PigContext.java:774)
    at org.apache.pig.parser.LogicalPlanBuilder.buildLoadOp(LogicalPlanBuilder.java:869)
    ... 19 more
Caused by: java.lang.reflect.InvocationTargetException
    at sun.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
    at sun.reflect.NativeConstructorAccessorImpl.newInstance(Unknown Source)
    at sun.reflect.DelegatingConstructorAccessorImpl.newInstance(Unknown Source)
    at java.lang.reflect.Constructor.newInstance(Unknown Source)
    at org.apache.pig.impl.PigContext.instantiateFuncFromSpec(PigContext.java:742)
    ... 20 more
Caused by: java.lang.RuntimeException: Failed to create WritableConverter instance
    at com.twitter.elephantbird.pig.util.SequenceFileConfig.getWritableConverter(SequenceFileConfig.java:225)
    at com.twitter.elephantbird.pig.util.SequenceFileConfig.<init>(SequenceFileConfig.java:102)
    at com.twitter.elephantbird.pig.load.SequenceFileLoader$Config.<init>(SequenceFileLoader.java:74)
    at com.twitter.elephantbird.pig.load.SequenceFileLoader.<init>(SequenceFileLoader.java:118)
    at com.twitter.elephantbird.pig.load.SequenceFileLoader.<init>(SequenceFileLoader.java:128)
    ... 25 more
Caused by: java.lang.NoSuchMethodException: com.twitter.elephantbird.pig.util.TextConverter.<init>(java.lang.String)
    at java.lang.Class.getConstructor0(Unknown Source)
    at java.lang.Class.getConstructor(Unknown Source)
    at com.twitter.elephantbird.pig.util.SequenceFileConfig.getWritableConverter(SequenceFileConfig.java:213)
    ... 29 more

The last inner error suggests the second argument was not correctly parsed and picked up the default `TextConverter` instead of the `ProtobufWritableConverter`.
