### PR TITLE
use progress() from HadoopCompat

### DIFF
--- a/core/src/main/java/com/twitter/elephantbird/mapreduce/input/MapReduceInputFormatWrapper.java
+++ b/core/src/main/java/com/twitter/elephantbird/mapreduce/input/MapReduceInputFormatWrapper.java
@@ -6,7 +6,6 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
-import com.twitter.elephantbird.util.HadoopCompat;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.io.Writable;
 import org.apache.hadoop.io.WritableUtils;
@@ -23,6 +22,7 @@ import org.apache.hadoop.mapreduce.TaskInputOutputContext;
 import org.apache.hadoop.mapreduce.lib.input.FileSplit;
 import org.apache.hadoop.util.ReflectionUtils;
 
+import com.twitter.elephantbird.util.HadoopCompat;
 import com.twitter.elephantbird.util.HadoopUtils;
 
 /**
@@ -167,7 +167,7 @@ public class MapReduceInputFormatWrapper<K, V> extends org.apache.hadoop.mapredu
                 context instanceof TaskInputOutputContext ?
                        (TaskInputOutputContext) context : null;
 
-        public void progress() { context.progress(); }
+        public void progress() { HadoopCompat.progress(context); }
 
         // @Override
         public float getProgress() {

--- a/core/src/main/java/com/twitter/elephantbird/util/TaskHeartbeatThread.java
+++ b/core/src/main/java/com/twitter/elephantbird/util/TaskHeartbeatThread.java
@@ -33,7 +33,7 @@ public class TaskHeartbeatThread {
             }
 
             // keep the task alive
-            context.progress();
+            HadoopCompat.progress(context);
 
             // call the optional custom progress method
             progress();


### PR DESCRIPTION
This fixes issue #393.

Should use HadoopCompat.progress() with a TaskAttemptContext so that it works with both Hadoop 1 & 2.
