### PR TITLE
Fix for ProtobufStructObjectInspector to work correctly with Hive

### DIFF
--- a/hive/src/main/java/com/twitter/elephantbird/hive/serde/ProtobufDeserializer.java
+++ b/hive/src/main/java/com/twitter/elephantbird/hive/serde/ProtobufDeserializer.java
@@ -44,8 +44,10 @@ public class ProtobufDeserializer implements Deserializer {
           .asSubclass(Message.class);
       protobufConverter = ProtobufConverter.newInstance(protobufClass);
 
+      Message.Builder builder = Protobufs.getMessageBuilder(protobufClass);
+
       Descriptor descriptor = Protobufs.getMessageDescriptor(protobufClass);
-      objectInspector = new ProtobufStructObjectInspector(descriptor);
+      objectInspector = new ProtobufStructObjectInspector(descriptor, builder);
     } catch (Exception e) {
       throw new SerDeException(e);
     }
@@ -54,7 +56,7 @@ public class ProtobufDeserializer implements Deserializer {
   @Override
   public Object deserialize(Writable blob) throws SerDeException {
     BytesWritable bytes = (BytesWritable) blob;
-    return protobufConverter.fromBytes(bytes.getBytes(), 0, bytes.getLength());
+    return protobufConverter.fromBytes(bytes.getBytes(), 0, bytes.getLength()).toBuilder();
   }
 
   @Override

--- a/hive/src/main/java/com/twitter/elephantbird/hive/serde/ProtobufStructObjectInspector.java
+++ b/hive/src/main/java/com/twitter/elephantbird/hive/serde/ProtobufStructObjectInspector.java
@@ -10,6 +10,7 @@ import com.google.protobuf.Descriptors.FieldDescriptor.JavaType;
 import com.google.protobuf.Descriptors.FieldDescriptor.Type;
 import com.google.protobuf.ByteString;
 import com.google.protobuf.Message;
+
 import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector;
 import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspectorFactory;
 import org.apache.hadoop.hive.serde2.objectinspector.PrimitiveObjectInspector.PrimitiveCategory;

--- a/hive/src/main/java/com/twitter/elephantbird/hive/serde/ProtobufStructObjectInspector.java
+++ b/hive/src/main/java/com/twitter/elephantbird/hive/serde/ProtobufStructObjectInspector.java
@@ -10,7 +10,6 @@ import com.google.protobuf.Descriptors.FieldDescriptor.JavaType;
 import com.google.protobuf.Descriptors.FieldDescriptor.Type;
 import com.google.protobuf.ByteString;
 import com.google.protobuf.Message;
-
 import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector;
 import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspectorFactory;
 import org.apache.hadoop.hive.serde2.objectinspector.PrimitiveObjectInspector.PrimitiveCategory;
@@ -20,201 +19,201 @@ import org.apache.hadoop.hive.serde2.objectinspector.primitive.PrimitiveObjectIn
 
 public final class ProtobufStructObjectInspector extends SettableStructObjectInspector {
 
-    public static class ProtobufStructField implements StructField {
+  public static class ProtobufStructField implements StructField {
 
-        private ObjectInspector oi = null;
-        private String comment = null;
-        private FieldDescriptor fieldDescriptor = null;
-        private Descriptor descriptor = null;
-        private Message.Builder builder = null;
+    private ObjectInspector oi = null;
+    private String comment = null;
+    private FieldDescriptor fieldDescriptor = null;
+    private Descriptor descriptor = null;
+    private Message.Builder builder = null;
 
-        @SuppressWarnings("unchecked")
-        public ProtobufStructField(FieldDescriptor fieldDescriptor) {
-            assert (fieldDescriptor != null);
-            this.fieldDescriptor = fieldDescriptor;
-            this.descriptor = null;
-            oi = this.createOIForField();
-        }
-
-        @SuppressWarnings("unchecked")
-        public ProtobufStructField(FieldDescriptor fd, Message.Builder builder) {
-            this.descriptor = fd.getMessageType();
-            this.fieldDescriptor = fd;
-            this.builder = builder;
-            oi = this.createOIForField();
-        }
-
-        @Override
-        public String getFieldName() {
-            return fieldDescriptor.getName();
-        }
-
-        @Override
-        public ObjectInspector getFieldObjectInspector() {
-            return oi;
-        }
-
-        @Override
-        public String getFieldComment() {
-            return comment;
-        }
-
-        public FieldDescriptor getFieldDescriptor() {
-            return fieldDescriptor;
-        }
-
-        private PrimitiveCategory getPrimitiveCategory(JavaType fieldType) {
-            switch (fieldType) {
-                case INT:
-                    return PrimitiveCategory.INT;
-                case LONG:
-                    return PrimitiveCategory.LONG;
-                case FLOAT:
-                    return PrimitiveCategory.FLOAT;
-                case DOUBLE:
-                    return PrimitiveCategory.DOUBLE;
-                case BOOLEAN:
-                    return PrimitiveCategory.BOOLEAN;
-                case STRING:
-                    return PrimitiveCategory.STRING;
-                case BYTE_STRING:
-                    return PrimitiveCategory.BINARY;
-                case ENUM:
-                    return PrimitiveCategory.STRING;
-                default:
-                    return null;
-            }
-        }
-
-        private ObjectInspector createOIForField() {
-            ObjectInspector elementOI = null;
-            if (descriptor != null) {
-                // this field is a Message
-                elementOI = new ProtobufStructObjectInspector(descriptor, builder);
-            } else {
-                JavaType fieldType = fieldDescriptor.getJavaType();
-                PrimitiveCategory category = getPrimitiveCategory(fieldType);
-                if (category != null) {
-                    elementOI = PrimitiveObjectInspectorFactory.getPrimitiveJavaObjectInspector(category);
-                }
-            }
-            if (fieldDescriptor.isRepeated()) {
-                return ObjectInspectorFactory.getStandardListObjectInspector(elementOI);
-            } else {
-                return elementOI;
-            }
-        }
+    @SuppressWarnings("unchecked")
+    public ProtobufStructField(FieldDescriptor fieldDescriptor) {
+      assert (fieldDescriptor != null);
+      this.fieldDescriptor = fieldDescriptor;
+      this.descriptor = null;
+      oi = this.createOIForField();
     }
 
-    private Descriptor descriptor;
-    private Message.Builder builder;
-    private List<StructField> structFields = Lists.newArrayList();
-
-    ProtobufStructObjectInspector(Descriptor descriptor, Message.Builder builder) {
-        this.descriptor = descriptor;
-        this.builder = builder;
-        for (FieldDescriptor fd : descriptor.getFields()) {
-            if (fd.getType() != Type.MESSAGE) {
-                structFields.add(new ProtobufStructField(fd));
-            } else {
-                structFields.add(new ProtobufStructField(fd, builder.newBuilderForField(fd)));
-            }
-        }
+    @SuppressWarnings("unchecked")
+    public ProtobufStructField(FieldDescriptor fd, Message.Builder builder) {
+      this.descriptor = fd.getMessageType();
+      this.fieldDescriptor = fd;
+      this.builder = builder;
+      oi = this.createOIForField();
     }
 
     @Override
-    public Category getCategory() {
-        return Category.STRUCT;
+    public String getFieldName() {
+      return fieldDescriptor.getName();
     }
 
     @Override
-    public String getTypeName() {
-        StringBuilder sb = new StringBuilder("struct<");
-        boolean first = true;
-        for (StructField structField : getAllStructFieldRefs()) {
-            if (first) {
-                first = false;
-            } else {
-                sb.append(",");
-            }
-            sb.append(structField.getFieldName()).append(":")
-                    .append(structField.getFieldObjectInspector().getTypeName());
-        }
-        sb.append(">");
-        return sb.toString();
+    public ObjectInspector getFieldObjectInspector() {
+      return oi;
     }
 
     @Override
-    public Object create() {
-        return builder;
+    public String getFieldComment() {
+      return comment;
     }
 
-    @Override
-    public Object setStructFieldData(Object data, StructField field, Object fieldValue) {
-        Message.Builder builder = (Message.Builder) data;
-        ProtobufStructField psf = (ProtobufStructField) field;
-        FieldDescriptor fieldDescriptor = psf.getFieldDescriptor();
-        if (fieldDescriptor.getType() != Type.MESSAGE) {
-            builder.setField(descriptor.findFieldByName(field.getFieldName()), fieldValue);
-        } else {
-            Message.Builder subFieldBuilder = (Message.Builder)fieldValue;
-            builder.setField(descriptor.findFieldByName(field.getFieldName()), subFieldBuilder.build());
-        }
-        return builder;
-
+    public FieldDescriptor getFieldDescriptor() {
+      return fieldDescriptor;
     }
 
-    @Override
-    public List<? extends StructField> getAllStructFieldRefs() {
-        return structFields;
+    private PrimitiveCategory getPrimitiveCategory(JavaType fieldType) {
+      switch (fieldType) {
+        case INT:
+          return PrimitiveCategory.INT;
+        case LONG:
+          return PrimitiveCategory.LONG;
+        case FLOAT:
+          return PrimitiveCategory.FLOAT;
+        case DOUBLE:
+          return PrimitiveCategory.DOUBLE;
+        case BOOLEAN:
+          return PrimitiveCategory.BOOLEAN;
+        case STRING:
+          return PrimitiveCategory.STRING;
+        case BYTE_STRING:
+          return PrimitiveCategory.BINARY;
+        case ENUM:
+          return PrimitiveCategory.STRING;
+        default:
+          return null;
+      }
     }
 
-    @Override
-    public Object getStructFieldData(Object data, StructField structField) {
-        if (data == null) {
-            return null;
+    private ObjectInspector createOIForField() {
+      ObjectInspector elementOI = null;
+      if (descriptor != null) {
+        // this field is a Message
+        elementOI = new ProtobufStructObjectInspector(descriptor, builder);
+      } else {
+        JavaType fieldType = fieldDescriptor.getJavaType();
+        PrimitiveCategory category = getPrimitiveCategory(fieldType);
+        if (category != null) {
+          elementOI = PrimitiveObjectInspectorFactory.getPrimitiveJavaObjectInspector(category);
         }
-        Message.Builder m = ((Message.Builder) data);
-        ProtobufStructField psf = (ProtobufStructField) structField;
-        FieldDescriptor fieldDescriptor = psf.getFieldDescriptor();
+      }
+      if (fieldDescriptor.isRepeated()) {
+        return ObjectInspectorFactory.getStandardListObjectInspector(elementOI);
+      } else {
+        return elementOI;
+      }
+    }
+  }
 
-        Object result = m.getField(fieldDescriptor);
-        if (fieldDescriptor.getType() == Type.ENUM) {
-            return ((EnumValueDescriptor) result).getName();
-        }
-        if (fieldDescriptor.getType() == Type.BYTES && (result instanceof ByteString)) {
-            return ((ByteString) result).toByteArray();
-        }
+  private Descriptor descriptor;
+  private Message.Builder builder;
+  private List<StructField> structFields = Lists.newArrayList();
 
-        if (fieldDescriptor.getType() == Type.MESSAGE && !fieldDescriptor.isRepeated()) {
-            result = ((Message) result).toBuilder();
-        }
+  ProtobufStructObjectInspector(Descriptor descriptor, Message.Builder builder) {
+    this.descriptor = descriptor;
+    this.builder = builder;
+    for (FieldDescriptor fd : descriptor.getFields()) {
+      if (fd.getType() != Type.MESSAGE) {
+        structFields.add(new ProtobufStructField(fd));
+      } else {
+        structFields.add(new ProtobufStructField(fd, builder.newBuilderForField(fd)));
+      }
+    }
+  }
 
-        return result;
+  @Override
+  public Category getCategory() {
+    return Category.STRUCT;
+  }
+
+  @Override
+  public String getTypeName() {
+    StringBuilder sb = new StringBuilder("struct<");
+    boolean first = true;
+    for (StructField structField : getAllStructFieldRefs()) {
+      if (first) {
+        first = false;
+      } else {
+        sb.append(",");
+      }
+      sb.append(structField.getFieldName()).append(":")
+          .append(structField.getFieldObjectInspector().getTypeName());
+    }
+    sb.append(">");
+    return sb.toString();
+  }
+
+  @Override
+  public Object create() {
+    return builder;
+  }
+
+  @Override
+  public Object setStructFieldData(Object data, StructField field, Object fieldValue) {
+    Message.Builder builder = (Message.Builder) data;
+    ProtobufStructField psf = (ProtobufStructField) field;
+    FieldDescriptor fieldDescriptor = psf.getFieldDescriptor();
+    if (fieldDescriptor.getType() != Type.MESSAGE) {
+      builder.setField(descriptor.findFieldByName(field.getFieldName()), fieldValue);
+    } else {
+      Message.Builder subFieldBuilder = (Message.Builder) fieldValue;
+      builder.setField(descriptor.findFieldByName(field.getFieldName()), subFieldBuilder.build());
+    }
+    return builder;
+
+  }
+
+  @Override
+  public List<? extends StructField> getAllStructFieldRefs() {
+    return structFields;
+  }
+
+  @Override
+  public Object getStructFieldData(Object data, StructField structField) {
+    if (data == null) {
+      return null;
+    }
+    Message.Builder m = ((Message.Builder) data);
+    ProtobufStructField psf = (ProtobufStructField) structField;
+    FieldDescriptor fieldDescriptor = psf.getFieldDescriptor();
+
+    Object result = m.getField(fieldDescriptor);
+    if (fieldDescriptor.getType() == Type.ENUM) {
+      return ((EnumValueDescriptor) result).getName();
+    }
+    if (fieldDescriptor.getType() == Type.BYTES && (result instanceof ByteString)) {
+      return ((ByteString) result).toByteArray();
     }
 
-    @Override
-    public StructField getStructFieldRef(String fieldName) {
-        FieldDescriptor fd = descriptor.findFieldByName(fieldName);
-        ProtobufStructField result = null;
-        if (fd.getType() != Type.MESSAGE) {
-             result = new ProtobufStructField(fd);
-        } else {
-            result = new ProtobufStructField(fd, builder.newBuilderForField(fd));
-        }
-        return result;
+    if (fieldDescriptor.getType() == Type.MESSAGE && !fieldDescriptor.isRepeated()) {
+      result = ((Message) result).toBuilder();
     }
 
-    @Override
-    public List<Object> getStructFieldsDataAsList(Object data) {
-        if (data == null) {
-            return null;
-        }
-        List<Object> result = Lists.newArrayList();
-        Message.Builder m = (Message.Builder) data;
-        for (FieldDescriptor fd : descriptor.getFields()) {
-            result.add(m.getField(fd));
-        }
-        return result;
+    return result;
+  }
+
+  @Override
+  public StructField getStructFieldRef(String fieldName) {
+    FieldDescriptor fd = descriptor.findFieldByName(fieldName);
+    ProtobufStructField result = null;
+    if (fd.getType() != Type.MESSAGE) {
+      result = new ProtobufStructField(fd);
+    } else {
+      result = new ProtobufStructField(fd, builder.newBuilderForField(fd));
     }
+    return result;
+  }
+
+  @Override
+  public List<Object> getStructFieldsDataAsList(Object data) {
+    if (data == null) {
+      return null;
+    }
+    List<Object> result = Lists.newArrayList();
+    Message.Builder m = (Message.Builder) data;
+    for (FieldDescriptor fd : descriptor.getFields()) {
+      result.add(m.getField(fd));
+    }
+    return result;
+  }
 }

--- a/hive/src/main/java/com/twitter/elephantbird/hive/serde/ProtobufStructObjectInspector.java
+++ b/hive/src/main/java/com/twitter/elephantbird/hive/serde/ProtobufStructObjectInspector.java
@@ -20,167 +20,201 @@ import org.apache.hadoop.hive.serde2.objectinspector.primitive.PrimitiveObjectIn
 
 public final class ProtobufStructObjectInspector extends SettableStructObjectInspector {
 
-  public static class ProtobufStructField implements StructField {
+    public static class ProtobufStructField implements StructField {
 
-    private ObjectInspector oi = null;
-    private String comment = null;
-    private FieldDescriptor fieldDescriptor;
+        private ObjectInspector oi = null;
+        private String comment = null;
+        private FieldDescriptor fieldDescriptor = null;
+        private Descriptor descriptor = null;
+        private Message.Builder builder = null;
 
-    @SuppressWarnings("unchecked")
-    public ProtobufStructField(FieldDescriptor fieldDescriptor) {
-      this.fieldDescriptor = fieldDescriptor;
-      oi = this.createOIForField();
-    }
-
-    @Override
-    public String getFieldName() {
-      return fieldDescriptor.getName();
-    }
-
-    @Override
-    public ObjectInspector getFieldObjectInspector() {
-      return oi;
-    }
-
-    @Override
-    public String getFieldComment() {
-      return comment;
-    }
-
-    public FieldDescriptor getFieldDescriptor() {
-      return fieldDescriptor;
-    }
-
-    private PrimitiveCategory getPrimitiveCategory(JavaType fieldType) {
-      switch (fieldType) {
-        case INT:
-          return PrimitiveCategory.INT;
-        case LONG:
-          return PrimitiveCategory.LONG;
-        case FLOAT:
-          return PrimitiveCategory.FLOAT;
-        case DOUBLE:
-          return PrimitiveCategory.DOUBLE;
-        case BOOLEAN:
-          return PrimitiveCategory.BOOLEAN;
-        case STRING:
-          return PrimitiveCategory.STRING;
-        case BYTE_STRING:
-          return PrimitiveCategory.BINARY;
-        case ENUM:
-          return PrimitiveCategory.STRING;
-        default:
-          return null;
-      }
-    }
-
-    private ObjectInspector createOIForField() {
-      JavaType fieldType = fieldDescriptor.getJavaType();
-      PrimitiveCategory category = getPrimitiveCategory(fieldType);
-      ObjectInspector elementOI = null;
-      if (category != null) {
-        elementOI = PrimitiveObjectInspectorFactory.getPrimitiveJavaObjectInspector(category);
-      } else {
-        switch (fieldType) {
-          case MESSAGE:
-            elementOI = new ProtobufStructObjectInspector(fieldDescriptor.getMessageType());
-            break;
-          default:
-            throw new RuntimeException("JavaType " + fieldType
-                + " from protobuf is not supported.");
+        @SuppressWarnings("unchecked")
+        public ProtobufStructField(FieldDescriptor fieldDescriptor) {
+            assert (fieldDescriptor != null);
+            this.fieldDescriptor = fieldDescriptor;
+            this.descriptor = null;
+            oi = this.createOIForField();
         }
-      }
-      if (fieldDescriptor.isRepeated()) {
-        return ObjectInspectorFactory.getStandardListObjectInspector(elementOI);
-      } else {
-        return elementOI;
-      }
+
+        @SuppressWarnings("unchecked")
+        public ProtobufStructField(FieldDescriptor fd, Message.Builder builder) {
+            this.descriptor = fd.getMessageType();
+            this.fieldDescriptor = fd;
+            this.builder = builder;
+            oi = this.createOIForField();
+        }
+
+        @Override
+        public String getFieldName() {
+            return fieldDescriptor.getName();
+        }
+
+        @Override
+        public ObjectInspector getFieldObjectInspector() {
+            return oi;
+        }
+
+        @Override
+        public String getFieldComment() {
+            return comment;
+        }
+
+        public FieldDescriptor getFieldDescriptor() {
+            return fieldDescriptor;
+        }
+
+        private PrimitiveCategory getPrimitiveCategory(JavaType fieldType) {
+            switch (fieldType) {
+                case INT:
+                    return PrimitiveCategory.INT;
+                case LONG:
+                    return PrimitiveCategory.LONG;
+                case FLOAT:
+                    return PrimitiveCategory.FLOAT;
+                case DOUBLE:
+                    return PrimitiveCategory.DOUBLE;
+                case BOOLEAN:
+                    return PrimitiveCategory.BOOLEAN;
+                case STRING:
+                    return PrimitiveCategory.STRING;
+                case BYTE_STRING:
+                    return PrimitiveCategory.BINARY;
+                case ENUM:
+                    return PrimitiveCategory.STRING;
+                default:
+                    return null;
+            }
+        }
+
+        private ObjectInspector createOIForField() {
+            ObjectInspector elementOI = null;
+            if (descriptor != null) {
+                // this field is a Message
+                elementOI = new ProtobufStructObjectInspector(descriptor, builder);
+            } else {
+                JavaType fieldType = fieldDescriptor.getJavaType();
+                PrimitiveCategory category = getPrimitiveCategory(fieldType);
+                if (category != null) {
+                    elementOI = PrimitiveObjectInspectorFactory.getPrimitiveJavaObjectInspector(category);
+                }
+            }
+            if (fieldDescriptor.isRepeated()) {
+                return ObjectInspectorFactory.getStandardListObjectInspector(elementOI);
+            } else {
+                return elementOI;
+            }
+        }
     }
-  }
 
-  private Descriptor descriptor;
-  private List<StructField> structFields = Lists.newArrayList();
+    private Descriptor descriptor;
+    private Message.Builder builder;
+    private List<StructField> structFields = Lists.newArrayList();
 
-  ProtobufStructObjectInspector(Descriptor descriptor) {
-    this.descriptor = descriptor;
-    for (FieldDescriptor fd : descriptor.getFields()) {
-      structFields.add(new ProtobufStructField(fd));
+    ProtobufStructObjectInspector(Descriptor descriptor, Message.Builder builder) {
+        this.descriptor = descriptor;
+        this.builder = builder;
+        for (FieldDescriptor fd : descriptor.getFields()) {
+            if (fd.getType() != Type.MESSAGE) {
+                structFields.add(new ProtobufStructField(fd));
+            } else {
+                structFields.add(new ProtobufStructField(fd, builder.newBuilderForField(fd)));
+            }
+        }
     }
-  }
 
-  @Override
-  public Category getCategory() {
-    return Category.STRUCT;
-  }
-
-  @Override
-  public String getTypeName() {
-    StringBuilder sb = new StringBuilder("struct<");
-    boolean first = true;
-    for (StructField structField : getAllStructFieldRefs()) {
-      if (first) {
-        first = false;
-      } else {
-        sb.append(",");
-      }
-      sb.append(structField.getFieldName()).append(":")
-          .append(structField.getFieldObjectInspector().getTypeName());
+    @Override
+    public Category getCategory() {
+        return Category.STRUCT;
     }
-    sb.append(">");
-    return sb.toString();
-  }
 
-  @Override
-  public Object create() {
-    return descriptor.toProto().toBuilder().build();
-  }
-
-  @Override
-  public Object setStructFieldData(Object data, StructField field, Object fieldValue) {
-    return ((Message) data)
-        .toBuilder()
-        .setField(descriptor.findFieldByName(field.getFieldName()), fieldValue)
-        .build();
-  }
-
-  @Override
-  public List<? extends StructField> getAllStructFieldRefs() {
-    return structFields;
-  }
-
-  @Override
-  public Object getStructFieldData(Object data, StructField structField) {
-    if (data == null) {
-      return null;
+    @Override
+    public String getTypeName() {
+        StringBuilder sb = new StringBuilder("struct<");
+        boolean first = true;
+        for (StructField structField : getAllStructFieldRefs()) {
+            if (first) {
+                first = false;
+            } else {
+                sb.append(",");
+            }
+            sb.append(structField.getFieldName()).append(":")
+                    .append(structField.getFieldObjectInspector().getTypeName());
+        }
+        sb.append(">");
+        return sb.toString();
     }
-    Message m = (Message) data;
-    ProtobufStructField psf = (ProtobufStructField) structField;
-    FieldDescriptor fieldDescriptor = psf.getFieldDescriptor();
-    Object result = m.getField(fieldDescriptor);
-    if (fieldDescriptor.getType() == Type.ENUM) {
-      return ((EnumValueDescriptor)result).getName();
-    }
-    if (fieldDescriptor.getType() == Type.BYTES && (result instanceof ByteString)) {
-        return ((ByteString)result).toByteArray();
-    }
-    return result;
-  }
 
-  @Override
-  public StructField getStructFieldRef(String fieldName) {
-    return new ProtobufStructField(descriptor.findFieldByName(fieldName));
-  }
+    @Override
+    public Object create() {
+        return builder;
+    }
 
-  @Override
-  public List<Object> getStructFieldsDataAsList(Object data) {
-    if (data == null) {
-      return null;
+    @Override
+    public Object setStructFieldData(Object data, StructField field, Object fieldValue) {
+        Message.Builder builder = (Message.Builder) data;
+        ProtobufStructField psf = (ProtobufStructField) field;
+        FieldDescriptor fieldDescriptor = psf.getFieldDescriptor();
+        if (fieldDescriptor.getType() != Type.MESSAGE) {
+            builder.setField(descriptor.findFieldByName(field.getFieldName()), fieldValue);
+        } else {
+            Message.Builder subFieldBuilder = (Message.Builder)fieldValue;
+            builder.setField(descriptor.findFieldByName(field.getFieldName()), subFieldBuilder.build());
+        }
+        return builder;
+
     }
-    List<Object> result = Lists.newArrayList();
-    Message m = (Message) data;
-    for (FieldDescriptor fd : descriptor.getFields()) {
-      result.add(m.getField(fd));
+
+    @Override
+    public List<? extends StructField> getAllStructFieldRefs() {
+        return structFields;
     }
-    return result;
-  }
+
+    @Override
+    public Object getStructFieldData(Object data, StructField structField) {
+        if (data == null) {
+            return null;
+        }
+        Message.Builder m = ((Message.Builder) data);
+        ProtobufStructField psf = (ProtobufStructField) structField;
+        FieldDescriptor fieldDescriptor = psf.getFieldDescriptor();
+
+        Object result = m.getField(fieldDescriptor);
+        if (fieldDescriptor.getType() == Type.ENUM) {
+            return ((EnumValueDescriptor) result).getName();
+        }
+        if (fieldDescriptor.getType() == Type.BYTES && (result instanceof ByteString)) {
+            return ((ByteString) result).toByteArray();
+        }
+
+        if (fieldDescriptor.getType() == Type.MESSAGE && !fieldDescriptor.isRepeated()) {
+            result = ((Message) result).toBuilder();
+        }
+
+        return result;
+    }
+
+    @Override
+    public StructField getStructFieldRef(String fieldName) {
+        FieldDescriptor fd = descriptor.findFieldByName(fieldName);
+        ProtobufStructField result = null;
+        if (fd.getType() != Type.MESSAGE) {
+             result = new ProtobufStructField(fd);
+        } else {
+            result = new ProtobufStructField(fd, builder.newBuilderForField(fd));
+        }
+        return result;
+    }
+
+    @Override
+    public List<Object> getStructFieldsDataAsList(Object data) {
+        if (data == null) {
+            return null;
+        }
+        List<Object> result = Lists.newArrayList();
+        Message.Builder m = (Message.Builder) data;
+        for (FieldDescriptor fd : descriptor.getFields()) {
+            result.add(m.getField(fd));
+        }
+        return result;
+    }
 }

--- a/hive/src/main/java/com/twitter/elephantbird/hive/serde/ProtobufStructObjectInspector.java
+++ b/hive/src/main/java/com/twitter/elephantbird/hive/serde/ProtobufStructObjectInspector.java
@@ -30,7 +30,6 @@ public final class ProtobufStructObjectInspector extends SettableStructObjectIns
 
     @SuppressWarnings("unchecked")
     public ProtobufStructField(FieldDescriptor fieldDescriptor) {
-      assert (fieldDescriptor != null);
       this.fieldDescriptor = fieldDescriptor;
       this.descriptor = null;
       oi = this.createOIForField();


### PR DESCRIPTION
Use builder class since hive expects mutable objects while message objects are immutable
