### PR TITLE
Add BooleanWritableConverter to use them in SequenceFileLoader in pig

### DIFF
--- a/pig/src/main/java/com/twitter/elephantbird/pig/util/BooleanWritableConverter.java
+++ b/pig/src/main/java/com/twitter/elephantbird/pig/util/BooleanWritableConverter.java
@@ -1,0 +1,96 @@
+package com.twitter.elephantbird.pig.util;
+
+import com.twitter.elephantbird.pig.util.AbstractWritableConverter;
+import org.apache.hadoop.io.BooleanWritable;
+import org.apache.pig.ResourceSchema;
+import org.apache.pig.data.DataByteArray;
+import org.apache.pig.data.DataType;
+
+import java.io.IOException;
+
+/**
+ * Supports conversion between Pig types and {@link org.apache.hadoop.io.BooleanWritable}.
+ * 
+ * @author Xu Wenhao
+ */
+public class BooleanWritableConverter extends AbstractWritableConverter<BooleanWritable> {
+  public BooleanWritableConverter() {
+    super(new BooleanWritable());
+  }
+
+  @Override
+  public ResourceSchema.ResourceFieldSchema getLoadSchema() throws IOException {
+    ResourceSchema.ResourceFieldSchema schema = new ResourceSchema.ResourceFieldSchema();
+    schema.setType(DataType.INTEGER);
+    return schema;
+  }
+
+  @Override
+  public Object bytesToObject(DataByteArray dataByteArray) throws IOException {
+    return bytesToInteger(dataByteArray.get());
+  }
+
+  @Override
+  protected String toCharArray(BooleanWritable writable) throws IOException {
+    return String.valueOf(writable.get());
+  }
+
+  @Override
+  protected Integer toInteger(BooleanWritable writable) throws IOException {
+    return writable.get() ? 1 : 0;
+  }
+
+  @Override
+  protected Long toLong(BooleanWritable writable) throws IOException {
+    return (long)( writable.get() ? 1:0);
+  }
+
+  @Override
+  protected Float toFloat(BooleanWritable writable) throws IOException {
+    return (float)( writable.get() ? 1:0);
+  }
+
+  @Override
+  protected Double toDouble(BooleanWritable writable) throws IOException {
+    return (double)( writable.get() ? 1: 0);
+  }
+
+  @Override
+  public void checkStoreSchema(ResourceSchema.ResourceFieldSchema schema) throws IOException {
+    switch (schema.getType()) {
+      case DataType.CHARARRAY:
+      case DataType.INTEGER:
+      case DataType.LONG:
+      case DataType.FLOAT:
+      case DataType.DOUBLE:
+        return;
+    }
+    throw new IOException("Pig type '" + DataType.findTypeName(schema.getType()) + "' unsupported");
+  }
+
+  @Override
+  protected BooleanWritable toWritable(String value) throws IOException {
+    return toWritable(Integer.parseInt(value));
+  }
+
+  @Override
+  protected BooleanWritable toWritable(Integer value) throws IOException {
+    writable.set(value.intValue() == 1 ? true : false);
+    return writable;
+  }
+
+  @Override
+  protected BooleanWritable toWritable(Long value) throws IOException {
+    return toWritable(value.intValue());
+  }
+
+  @Override
+  protected BooleanWritable toWritable(Float value) throws IOException {
+    return toWritable(value.intValue());
+  }
+
+  @Override
+  protected BooleanWritable toWritable(Double value) throws IOException {
+    return toWritable(value.intValue());
+  }
+}

--- a/pig/src/main/java/com/twitter/elephantbird/pig/util/BooleanWritableConverter.java
+++ b/pig/src/main/java/com/twitter/elephantbird/pig/util/BooleanWritableConverter.java
@@ -1,6 +1,5 @@
 package com.twitter.elephantbird.pig.util;
 
-import com.twitter.elephantbird.pig.util.AbstractWritableConverter;
 import org.apache.hadoop.io.BooleanWritable;
 import org.apache.pig.ResourceSchema;
 import org.apache.pig.data.DataByteArray;
@@ -63,6 +62,7 @@ public class BooleanWritableConverter extends AbstractWritableConverter<BooleanW
       case DataType.LONG:
       case DataType.FLOAT:
       case DataType.DOUBLE:
+      case DataType.BOOLEAN:
         return;
     }
     throw new IOException("Pig type '" + DataType.findTypeName(schema.getType()) + "' unsupported");
@@ -99,5 +99,10 @@ public class BooleanWritableConverter extends AbstractWritableConverter<BooleanW
   @Override
   protected BooleanWritable toWritable(Double value) throws IOException {
     return toWritable(value.intValue());
+  }
+
+  @Override
+  protected BooleanWritable toWritable(Boolean value) throws IOException {
+    return toWritable(value.booleanValue() ? 1 : 0);
   }
 }

--- a/pig/src/main/java/com/twitter/elephantbird/pig/util/BooleanWritableConverter.java
+++ b/pig/src/main/java/com/twitter/elephantbird/pig/util/BooleanWritableConverter.java
@@ -42,17 +42,17 @@ public class BooleanWritableConverter extends AbstractWritableConverter<BooleanW
 
   @Override
   protected Long toLong(BooleanWritable writable) throws IOException {
-    return (long)( writable.get() ? 1:0);
+    return writable.get() ? 1L : 0L;
   }
 
   @Override
   protected Float toFloat(BooleanWritable writable) throws IOException {
-    return (float)( writable.get() ? 1:0);
+    return writable.get() ? 1f : 0f;
   }
 
   @Override
   protected Double toDouble(BooleanWritable writable) throws IOException {
-    return (double)( writable.get() ? 1: 0);
+    return writable.get() ? 1.0 : 0.0;
   }
 
   @Override
@@ -75,7 +75,14 @@ public class BooleanWritableConverter extends AbstractWritableConverter<BooleanW
 
   @Override
   protected BooleanWritable toWritable(Integer value) throws IOException {
-    writable.set(value.intValue() == 1 ? true : false);
+    int valueInt = value.intValue();
+    if (valueInt == 1 ) {
+      writable.set(true);
+    } else if (valueInt == 0) {
+      writable.set(false);
+    } else {
+      throw new IllegalArgumentException("Only 1 and 0 could be convert to BooleanWritable!");
+    }
     return writable;
   }
 

--- a/pig/src/test/java/com/twitter/elephantbird/pig/util/IntegrationTestBooleanWritableConverter.java
+++ b/pig/src/test/java/com/twitter/elephantbird/pig/util/IntegrationTestBooleanWritableConverter.java
@@ -8,9 +8,9 @@ import org.apache.hadoop.io.BooleanWritable;
 public class IntegrationTestBooleanWritableConverter extends
     AbstractTestWritableConverter<BooleanWritable, BooleanWritableConverter> {
   private static final BooleanWritable[] DATA = { new BooleanWritable(true), new BooleanWritable(false)};
-  private static final String[] EXPECTED = { "true", "false" };
+  private static final String[] EXPECTED = { "1", "0" };
 
   public IntegrationTestBooleanWritableConverter() {
-    super(BooleanWritable.class, BooleanWritableConverter.class, "", DATA, EXPECTED, "boolean");
+    super(BooleanWritable.class, BooleanWritableConverter.class, "", DATA, EXPECTED, "int");
   }
 }

--- a/pig/src/test/java/com/twitter/elephantbird/pig/util/IntegrationTestBooleanWritableConverter.java
+++ b/pig/src/test/java/com/twitter/elephantbird/pig/util/IntegrationTestBooleanWritableConverter.java
@@ -1,0 +1,16 @@
+package com.twitter.elephantbird.pig.util;
+
+import org.apache.hadoop.io.BooleanWritable;
+
+/**
+ * @author Xu Wenhao
+ */
+public class IntegrationTestBooleanWritableConverter extends
+    AbstractTestWritableConverter<BooleanWritable, BooleanWritableConverter> {
+  private static final BooleanWritable[] DATA = { new BooleanWritable(true), new BooleanWritable(false)};
+  private static final String[] EXPECTED = { "true", "false" };
+
+  public IntegrationTestBooleanWritableConverter() {
+    super(BooleanWritable.class, BooleanWritableConverter.class, "", DATA, EXPECTED, "boolean");
+  }
+}


### PR DESCRIPTION
I have used BooleanWritable as a key or value in SequenceFile, since BooleanWritable is built inside hadoop, I suggest to have BooleanWritableConverter built into the elephant-bird. 
