### PR TITLE
Fix NPE in CompositeRecordReader due to improper delegate initialization

### DIFF
--- a/core/src/main/java/com/twitter/elephantbird/mapreduce/input/combine/CompositeRecordReader.java
+++ b/core/src/main/java/com/twitter/elephantbird/mapreduce/input/combine/CompositeRecordReader.java
@@ -150,7 +150,11 @@ public class CompositeRecordReader<K, V> extends RecordReader<K, V>
   @Override
   public float getProgress() throws IOException, InterruptedException {
     if (recordReadersCount < 1) {
-      return 1.0f;
+      return 1f;
+    }
+
+    if (totalSplitLengths == 0) {
+      return 0f;
     }
 
     long cur = currentRecordReader == null ?


### PR DESCRIPTION
The initial split created by the delegate in CompositeRecordReader should
provide the key/value objects used for the rest of processing. This was not
the case, which led to an NPE. Also, there was an issue in the getProgress
method.
