### PR TITLE
Don't copy the array before handing it for base64 decode

### DIFF
--- a/core/src/main/java/com/twitter/elephantbird/mapreduce/input/Base64Codec.java
+++ b/core/src/main/java/com/twitter/elephantbird/mapreduce/input/Base64Codec.java
@@ -225,10 +225,9 @@ public class Base64Codec
    * @param sArr The source array. Length 0 will return an empty array. <code>null</code> will throw an exception.
    * @return The decoded array of bytes. May be of length 0.
    */
-  public final static byte[] decodeFast(byte[] sArr)
+  public final static byte[] decodeFast(byte[] sArr, int sLen)
   {
     // Check special case
-    int sLen = sArr.length;
     if (sLen == 0)
       return new byte[0];
 

--- a/core/src/main/java/com/twitter/elephantbird/mapreduce/input/LzoBinaryB64LineRecordReader.java
+++ b/core/src/main/java/com/twitter/elephantbird/mapreduce/input/LzoBinaryB64LineRecordReader.java
@@ -139,8 +139,7 @@ public class  LzoBinaryB64LineRecordReader<M, W extends BinaryWritable<M>>
       Throwable decodeException = null;
 
       try {
-        byte[] lineBytes = Arrays.copyOf(line_.getBytes(), line_.getLength());
-        protoValue = converter_.fromBytes(Base64Codec.decodeFast(lineBytes));
+        protoValue = converter_.fromBytes(Base64Codec.decodeFast(line_.getBytes(), line_.getLength()));
       } catch(Throwable t1) {
         decodeException = t1;
       }


### PR DESCRIPTION
Adding what @rangadi spotted that the copy is un-necessary. I suspect there is probably another decent win turning the base64 operation and the read line into iterator ops. So we can just materialize the new base64 decoded array[byte] than the intermediate also.2
