### PR TITLE
avoid double reading first block in split in block-format

### DIFF
--- a/core/src/main/java/com/twitter/elephantbird/mapreduce/input/LzoBinaryBlockRecordReader.java
+++ b/core/src/main/java/com/twitter/elephantbird/mapreduce/input/LzoBinaryBlockRecordReader.java
@@ -119,11 +119,10 @@ public class LzoBinaryBlockRecordReader<M, W extends BinaryWritable<M>>
   public boolean nextKeyValue() throws IOException, InterruptedException {
     // If we are past the end of the file split, tell the reader not to read any more new blocks.
     // Then continue reading until the last of the reader's already-parsed values are used up.
-    // The next split will start at the next sync point and no records will be missed.
     while (true) { // loop to skip over bad records
       if (pos_ > end_) {
         reader_.markNoMoreNewBlocks();
-        // Why not pos_ >= end_, stop when when we just reached the end?
+        // Why not pos_ >= end_, stop when we just reach the end?
         // we don't know if we have read all the bytes uncompressed in the current lzo block,
         // only way to make sure that we have read all of the split is to read till the
         // first record that has at least one byte in the next split.

--- a/core/src/main/java/com/twitter/elephantbird/mapreduce/input/LzoBinaryBlockRecordReader.java
+++ b/core/src/main/java/com/twitter/elephantbird/mapreduce/input/LzoBinaryBlockRecordReader.java
@@ -93,6 +93,9 @@ public class LzoBinaryBlockRecordReader<M, W extends BinaryWritable<M>>
     // No need to skip to the sync point here; the block reader will do it for us.
     LOG.debug("LzoProtobufBlockRecordReader.skipToNextSyncPoint called with atFirstRecord = " + atFirstRecord);
     updatePosition = !atFirstRecord;
+    // except for the first split, skip a protobuf block if it starts exactly at the split boundary
+    // because such a block would be read by the previous split
+    reader_.parseNextBlock(!atFirstRecord);
   }
 
   @Override

--- a/core/src/main/java/com/twitter/elephantbird/mapreduce/io/BinaryBlockReader.java
+++ b/core/src/main/java/com/twitter/elephantbird/mapreduce/io/BinaryBlockReader.java
@@ -133,10 +133,6 @@ public abstract class BinaryBlockReader<M> {
       return null;
     }
 
-    if (skipIfStartingOnBoundary && skipped == Protobufs.KNOWN_GOOD_POSITION_MARKER.length) {
-      return parseNextBlock(false);
-    }
-
     int blockSize = readInt();
     LOG.debug("BlockReader: found sync point, next block has size " + blockSize);
     if (blockSize < 0) {
@@ -147,6 +143,12 @@ public abstract class BinaryBlockReader<M> {
 
     byte[] byteArray = new byte[blockSize];
     IOUtils.readFully(in_, byteArray, 0, blockSize);
+
+    if (skipIfStartingOnBoundary && skipped == Protobufs.KNOWN_GOOD_POSITION_MARKER.length) {
+      // skip the current current block
+      return parseNextBlock(false);
+    }
+
     SerializedBlock block = SerializedBlock.parseFrom(byteArray);
 
     curBlobs_ = block.getProtoBlobs();

--- a/core/src/main/java/com/twitter/elephantbird/mapreduce/io/BinaryBlockReader.java
+++ b/core/src/main/java/com/twitter/elephantbird/mapreduce/io/BinaryBlockReader.java
@@ -127,7 +127,7 @@ public abstract class BinaryBlockReader<M> {
   public List<ByteString> parseNextBlock(boolean skipIfStartingOnBoundary) throws IOException {
     LOG.debug("BlockReader: none left to read, skipping to sync point");
     long skipped = skipToNextSyncPoint();
-    if (skipped < -1) {
+    if (skipped <= -1) {
       LOG.debug("BlockReader: SYNC point eof");
       // EOF if there are no more sync markers.
       return null;

--- a/core/src/main/java/com/twitter/elephantbird/util/StreamSearcher.java
+++ b/core/src/main/java/com/twitter/elephantbird/util/StreamSearcher.java
@@ -37,14 +37,18 @@ public class StreamSearcher {
    * byte AFTER the pattern. Else, the stream is entirely consumed. The latter is because InputStream semantics make it difficult to have
    * another reasonable default, i.e. leave the stream unchanged.
    *
-   * @return true if found, false otherwise.
+   * @return bytes consumed if found, -1 otherwise.
    * @throws IOException
    */
-  public boolean search(InputStream stream) throws IOException {
-    int b = 0;
+  public long search(InputStream stream) throws IOException {
+    long bytesRead = 0;
+
+    int b;
     int j = 0;
 
     while ((b = stream.read()) != -1) {
+      bytesRead++;
+
       while (j >= 0 && (byte)b != pattern_[j]) {
         j = borders_[j];
       }
@@ -55,12 +59,12 @@ public class StreamSearcher {
       // which will automatically save our position in the InputStream at the point immediately
       // following the pattern match.
       if (j == pattern_.length) {
-        return true;
+        return bytesRead;
       }
     }
 
-    // No dice, return false.  Note that the stream is now completely consumed.
-    return false;
+    // No dice, Note that the stream is now completely consumed.
+    return -1;
   }
 
   /**

--- a/pig/src/test/java/com/twitter/elephantbird/pig/load/TestBinaryLoaderWithManySplits.java
+++ b/pig/src/test/java/com/twitter/elephantbird/pig/load/TestBinaryLoaderWithManySplits.java
@@ -81,15 +81,14 @@ public class TestBinaryLoaderWithManySplits {
     pigServer.getPigContext().getProperties().setProperty(
         "mapred.max.split.size", "1024");
 
-        // set low block size
     pigServer.registerQuery(String.format(
         "A = load '%s' using %s as (bytes);\n",
         inputDir.toURI().toString(),
         LzoRawBytesLoader.class.getName()));
 
     Iterator<Tuple> rows = pigServer.openIterator("A");
-    // verify:
 
+    // verify:
     // read all the records and sort them since the splits are not processed in order
     ArrayList<Byte> actual = new ArrayList(expectedRecords.length);
     while (rows.hasNext()) {

--- a/pig/src/test/java/com/twitter/elephantbird/pig/load/TestBinaryLoaderWithManySplits.java
+++ b/pig/src/test/java/com/twitter/elephantbird/pig/load/TestBinaryLoaderWithManySplits.java
@@ -60,7 +60,7 @@ public class TestBinaryLoaderWithManySplits {
     // use just one record for each protobuf block so that we have lots of records at
     // lzo level
     BinaryBlockWriter<byte[]> blk_writer = new BinaryBlockWriter<byte[]>(
-        createLzoOut("1-block.lzo", conf), byte[].class, new IdentityBinaryConverter(), 1) {};
+        createLzoOut("many-blocks.lzo", conf), byte[].class, new IdentityBinaryConverter(), 1) {};
 
     Random rand = new Random(20150107L);
     for (int i=0; i<NUM_RECORDS; i++) {

--- a/pig/src/test/java/com/twitter/elephantbird/pig/load/TestBinaryLoaderWithManySplits.java
+++ b/pig/src/test/java/com/twitter/elephantbird/pig/load/TestBinaryLoaderWithManySplits.java
@@ -1,0 +1,126 @@
+package com.twitter.elephantbird.pig.load;
+
+import java.io.DataOutputStream;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.Random;
+
+import com.google.common.primitives.Bytes;
+import com.twitter.elephantbird.mapreduce.io.BinaryBlockWriter;
+import com.twitter.elephantbird.mapreduce.io.IdentityBinaryConverter;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileUtil;
+import org.apache.pig.PigServer;
+import org.apache.pig.data.DataByteArray;
+import org.apache.pig.data.Tuple;
+import org.junit.Assert;
+import org.junit.Assume;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.hadoop.compression.lzo.LzopCodec;
+import com.twitter.elephantbird.pig.util.PigTestUtil;
+import com.twitter.elephantbird.util.CoreTestUtil;
+
+/**
+ * Tests lzo loader with many splits (about 8K) to trigger corner cases.
+ * Creates an indexed lzo file with 1M 1-byte records.
+ *
+ * The lzo buffer size is set to 512 bytes (default 256KB) so that we end up
+ * with lots of lzo blocks.
+ *
+ * While loading in pig, set max split size to 1K. This verifies a bug fix
+ * where the binary block reader was reading some records twice (pull #429).
+ */
+public class TestBinaryLoaderWithManySplits {
+
+  private PigServer pigServer;
+  private final String testDir =
+      System.getProperty("test.build.data") + "/TestBinvaryLoaderWithManySplits";
+  private final File inputDir = new File(testDir, "in");
+
+  private final int NUM_RECORDS = 1000 * 1000;
+  private final byte[] expectedRecords = new byte[NUM_RECORDS];
+
+  @Before
+  public void setUp() throws Exception {
+
+    Configuration conf = new Configuration();
+    Assume.assumeTrue(CoreTestUtil.okToRunLzoTests(conf));
+
+    pigServer = PigTestUtil.makePigServer();
+
+    inputDir.mkdirs();
+
+    // write to block file.
+    // use just one record for each protobuf block so that we have lots of records at
+    // lzo level
+    BinaryBlockWriter<byte[]> blk_writer = new BinaryBlockWriter<byte[]>(
+        createLzoOut("1-block.lzo", conf), byte[].class, new IdentityBinaryConverter(), 1) {};
+
+    Random rand = new Random(20150107L);
+    for (int i=0; i<NUM_RECORDS; i++) {
+      expectedRecords[i] = (byte) rand.nextInt();
+    }
+
+    for (byte b : expectedRecords) {
+      blk_writer.write(new byte[]{ b });
+    }
+    blk_writer.close();
+  }
+
+  @Test
+  public void testLoaderWithMultiplePartitions() throws Exception {
+    //setUp might not have run because of missing lzo native libraries
+    Assume.assumeTrue(pigServer != null);
+
+    pigServer.getPigContext().getProperties().setProperty(
+        "mapred.max.split.size", "1024");
+
+        // set low block size
+    pigServer.registerQuery(String.format(
+        "A = load '%s' using %s as (bytes);\n",
+        inputDir.toURI().toString(),
+        LzoRawBytesLoader.class.getName()));
+
+    Iterator<Tuple> rows = pigServer.openIterator("A");
+    // verify:
+
+    // read all the records and sort them since the splits are not processed in order
+    ArrayList<Byte> actual = new ArrayList(expectedRecords.length);
+    while (rows.hasNext()) {
+      actual.add(((DataByteArray)rows.next().get(0)).get()[0]);
+    }
+    byte[] actualRecords = Bytes.toArray(actual);
+
+    Assert.assertEquals(expectedRecords.length, actual.size());
+
+    Arrays.sort(expectedRecords);
+    Arrays.sort(actualRecords);
+
+    Assert.assertArrayEquals(expectedRecords, actualRecords);
+
+    FileUtil.fullyDelete(inputDir);
+  }
+
+  private DataOutputStream createLzoOut(String name, Configuration conf) throws IOException {
+    File file = new File(inputDir, name);
+    File indexFile = new File(inputDir, name + ".index");
+
+    LzopCodec codec = new LzopCodec();
+    // set very small lzo blocks size so that we have lots of them.
+    conf.setInt("io.compression.codec.lzo.buffersize", 512);
+    codec.setConf(conf);
+
+    if (file.exists()) {
+      file.delete();
+    }
+
+    return new DataOutputStream(codec.createIndexedOutputStream(new FileOutputStream(file),
+        new DataOutputStream(new FileOutputStream(indexFile))));
+  }
+}


### PR DESCRIPTION
If protobuf block starts exactly at the split boundary, it was double read, both by the current split and by the previous split. This patch makes the current split reader skip the first block if it starts exactly at the split boundary (this is equivalent to skipping first line in line_record readers).