### PR TITLE
Speed up getSplits by reusing FileStatus'es from the very first listStatus

### DIFF
--- a/core/src/main/java/com/twitter/elephantbird/mapreduce/input/LzoInputFormat.java
+++ b/core/src/main/java/com/twitter/elephantbird/mapreduce/input/LzoInputFormat.java
@@ -168,8 +168,7 @@ public abstract class LzoInputFormat<K, V> extends FileInputFormat<K, V> {
         if (LOG.isDebugEnabled()) {
           LOG.debug("Cached file status " + lzoSplitStatus);
         }
-        final FileStatus indexFileStatus = lzoSplitStatus
-            .lzoIndexFileStatus;
+        final FileStatus indexFileStatus = lzoSplitStatus.lzoIndexFileStatus;
         index = indexFileStatus == null
             ? new LzoIndex()
             : LzoIndex.readIndex(

--- a/core/src/main/java/com/twitter/elephantbird/mapreduce/input/LzoInputFormat.java
+++ b/core/src/main/java/com/twitter/elephantbird/mapreduce/input/LzoInputFormat.java
@@ -2,8 +2,10 @@ package com.twitter.elephantbird.mapreduce.input;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 
 import com.twitter.elephantbird.util.HadoopCompat;
 import org.apache.hadoop.fs.FileStatus;
@@ -44,10 +46,32 @@ public abstract class LzoInputFormat<K, V> extends FileInputFormat<K, V> {
     @Override
     public boolean accept(Path path) {
       String name = path.getName();
-      return !name.startsWith(".") &&
-             !name.startsWith("_") &&
+      return hiddenPathFilter.accept(path) &&
              name.endsWith(".lzo");
     }};
+
+  private final PathFilter lzoIndexFilter = new PathFilter() {
+    @Override
+    public boolean accept(Path path) {
+      final String name = path.getName();
+      return hiddenPathFilter.accept(path) &&
+             name.endsWith(LzoIndex.LZO_INDEX_SUFFIX);
+    }
+  };
+
+  private static class LzoSplitStatus {
+    private FileStatus lzoFileStatus;
+    private FileStatus lzoIndexFileStatus;
+
+    @Override
+    public String toString() {
+      return LzoSplitStatus.class.getName() + "[ lzo=" + lzoFileStatus
+          + " index=" + lzoIndexFileStatus + " ]";
+    }
+  }
+
+  private final Map<Path,LzoSplitStatus> splitStatusMap
+      = new HashMap<Path,LzoSplitStatus>();
 
   @Override
   protected List<FileStatus> listStatus(JobContext job) throws IOException {
@@ -61,15 +85,16 @@ public abstract class LzoInputFormat<K, V> extends FileInputFormat<K, V> {
       FileSystem fs = fileStatus.getPath().getFileSystem(HadoopCompat.getConfiguration(job));
       addInputPath(results, fs, fileStatus, recursive);
     }
-
-    LOG.debug("Total lzo input paths to process : " + results.size());
+    if (LOG.isDebugEnabled()) {
+      LOG.debug("Total lzo input paths to process : " + results.size());
+    }
     return results;
   }
 
   //MAPREDUCE-1501
   /**
    * Add lzo file(s). If recursive is set, traverses the directories.
-   * @param result
+   * @param results
    *          The List to store all files.
    * @param fs
    *          The FileSystem.
@@ -90,7 +115,23 @@ public abstract class LzoInputFormat<K, V> extends FileInputFormat<K, V> {
       }
     } else if ( visibleLzoFilter.accept(path) ) {
       results.add(pathStat);
+      lzoSplitStatus(path).lzoFileStatus = pathStat;
+    } else if (lzoIndexFilter.accept(path)) {
+      final String lzoIndexName = path.getName();
+      final String lzoName = lzoIndexName.substring(0, lzoIndexName.length() -
+          LzoIndex.LZO_INDEX_SUFFIX.length());
+      final Path lzoPath = new Path(path.getParent(), lzoName);
+      lzoSplitStatus(lzoPath).lzoIndexFileStatus = pathStat;
     }
+  }
+
+  private LzoSplitStatus lzoSplitStatus(Path path) {
+    LzoSplitStatus lzoSplitStatus = splitStatusMap.get(path);
+    if (lzoSplitStatus == null) {
+      lzoSplitStatus = new LzoSplitStatus();
+      splitStatusMap.put(path, lzoSplitStatus);
+    }
+    return lzoSplitStatus;
   }
 
   @Override
@@ -100,16 +141,12 @@ public abstract class LzoInputFormat<K, V> extends FileInputFormat<K, V> {
      * this.getSplit(). Right now, FileInputFormat splits across the
      * blocks and this.getSplits() adjusts the positions.
      */
-    try {
-      FileSystem fs = filename.getFileSystem(HadoopCompat.getConfiguration(context) );
-      return fs.exists( filename.suffix( LzoIndex.LZO_INDEX_SUFFIX ) );
-    } catch (IOException e) { // not expected
-      throw new RuntimeException(e);
-    }
+    LzoSplitStatus lzoSplitStatus = splitStatusMap.get(filename);
+    return lzoSplitStatus != null && lzoSplitStatus.lzoIndexFileStatus != null;
   }
 
-  @Override
-  public List<InputSplit> getSplits(JobContext job) throws IOException {
+  private List<InputSplit> getSplitsInternal(JobContext job)
+      throws IOException {
     List<InputSplit> defaultSplits = super.getSplits(job);
 
     // Find new starts and ends of the file splits that align with the lzo blocks.
@@ -124,10 +161,19 @@ public abstract class LzoInputFormat<K, V> extends FileInputFormat<K, V> {
       Path file = fileSplit.getPath();
 
       LzoIndex index; // reuse index for files with multiple blocks.
+      final LzoSplitStatus lzoSplitStatus = splitStatusMap.get(file);
       if ( file.equals(prevFile) ) {
         index = prevIndex;
       } else {
-        index = LzoIndex.readIndex(file.getFileSystem(HadoopCompat.getConfiguration(job)), file);
+        if (LOG.isDebugEnabled()) {
+          LOG.debug("Cached file status " + lzoSplitStatus);
+        }
+        final FileStatus indexFileStatus = lzoSplitStatus
+            .lzoIndexFileStatus;
+        index = indexFileStatus == null
+            ? new LzoIndex()
+            : LzoIndex.readIndex(
+                  file.getFileSystem(HadoopCompat.getConfiguration(job)), file);
         prevFile = file;
         prevIndex = index;
       }
@@ -148,11 +194,14 @@ public abstract class LzoInputFormat<K, V> extends FileInputFormat<K, V> {
       long end = start + fileSplit.getLength();
 
       long lzoStart = index.alignSliceStartToIndex(start, end);
-      long lzoEnd = index.alignSliceEndToIndex(end, file.getFileSystem(HadoopCompat.getConfiguration(job)).getFileStatus(file).getLen());
+      long lzoEnd = index.alignSliceEndToIndex(end,
+          lzoSplitStatus.lzoFileStatus.getLen());
 
       if (lzoStart != LzoIndex.NOT_FOUND  && lzoEnd != LzoIndex.NOT_FOUND) {
         result.add(new FileSplit(file, lzoStart, lzoEnd - lzoStart, fileSplit.getLocations()));
-        LOG.debug("Added LZO split for " + file + "[start=" + lzoStart + ", length=" + (lzoEnd - lzoStart) + "]");
+        if (LOG.isDebugEnabled()) {
+          LOG.debug("Added LZO split for " + file + "[start=" + lzoStart + ", length=" + (lzoEnd - lzoStart) + "]");
+        }
       }
       // else ignore the data?
       // should handle splitting the entire file here so that
@@ -160,5 +209,14 @@ public abstract class LzoInputFormat<K, V> extends FileInputFormat<K, V> {
     }
 
     return result;
+  }
+
+  @Override
+  public List<InputSplit> getSplits(JobContext job) throws IOException {
+    try {
+      return getSplitsInternal(job);
+    } finally {
+      splitStatusMap.clear(); // no use beyond getSplits
+    }
   }
 }


### PR DESCRIPTION
This is a preliminary version for our fixit/performance week at Twitter. It halves the number of RPC's. 

For benchmark I used a standalone tool that just calls getSplits https://github.com/gerashegalov/testsplits/blob/master/src/main/java/SplitBench.java

I generated 100 lzo files with 
```
HADOOP_CLASSPATH='./eb-4.6/*' hadoop jar hadoop-mapreduce-examples-2.4.0.t04.jar randomtextwriter -Dmapreduce.randomtextwriter.totalbytes=$((10000*1024*1024)) -Dmapreduce.randomtextwriter.bytespermap=$((1024*1024)) -libjars $(find './eb-4.6' -name \*jar | tr -s '\n' ',') -outFormat com.twitter.elephantbird.mapreduce.output.LzoTextOutputFormat rand
```
each file is about 300K after compression (i.e., single HDFS block). The files are indexed using DistibutedLzoIndexer depending on the test case. The tests are run over a thin link between DC with about 100ms RTT.

The following cases are considered:
*100 unindexed lzo files*

eb-4.6 (current):

4.6-hdfs-noindex-debug.log:
getSplits took (ms): 18051 for 100 splits

```
$ grep ipc.ProtobufRpcEngine 4.6-hdfs-noindex-debug.log | awk '{print $6}' | sort | uniq -c
    102 getFileInfo
      1 getListing
      1 rpcRequestWrapperClass=class
```

eb-4.7-SNAPSHOT (this PR):
4.7-hdfs-noindex-debug.log:getSplits took (ms): 1421 for 100 splits

```
$ grep ipc.ProtobufRpcEngine 4.7-hdfs-noindex-debug.log | awk '{print $6}' | sort | uniq -c
      2 getFileInfo
      1 getListing
      1 rpcRequestWrapperClass=class
```

As one can see the new solution is an O(1) operation that will look even better for more populated directories.

*100 indexed lzo files* 

eb-4.6 (current):

4.6-hdfs-index-debug.log:getSplits took (ms): 39958 for 100 splits

```
$ grep ipc.ProtobufRpcEngine 4.6-hdfs-index-debug.log | awk '{print $6}' | sort | uniq -c
    100 getBlockLocations
    202 getFileInfo
      1 getListing
      1 getServerDefaults
```

eb-4.7-SNAPSHOT (this PR)

4.7-hdfs-index-debug.log:getSplits took (ms): 22327 for 100 splits

```
$ grep ipc.ProtobufRpcEngine 4.7-hdfs-index-debug.log | awk '{print $6}' | sort | uniq -c
    100 getBlockLocations
      2 getFileInfo
      1 getListing
      1 getServerDefaults
      1 rpcRequestWrapperClass=class
```

We got rid of 2*n unnecessary getFileStatus with 1.7x latency improvement. It should be more with more populated directories. 