### PR TITLE
Faster working with LzoBinary data

### DIFF
--- a/cascading2/src/main/java/com/twitter/elephantbird/cascading2/scheme/LzoBinaryScheme.java
+++ b/cascading2/src/main/java/com/twitter/elephantbird/cascading2/scheme/LzoBinaryScheme.java
@@ -17,6 +17,7 @@ import cascading.scheme.Scheme;
 import cascading.scheme.SinkCall;
 import cascading.scheme.SourceCall;
 import cascading.tap.Tap;
+import cascading.tuple.Fields;
 import cascading.tuple.Tuple;
 import cascading.tuple.TupleEntry;
 
@@ -30,6 +31,10 @@ abstract public class LzoBinaryScheme<M, T extends BinaryWritable<M>> extends
 
   private static final Logger LOG = LoggerFactory.getLogger(LzoBinaryScheme.class);
   private static final long serialVersionUID = -5011096855302946106L;
+
+  public LzoBinaryScheme() {
+    super(Fields.FIRST);
+  }
 
   @Override
   public void sink(FlowProcess<JobConf> flowProcess, SinkCall<T, OutputCollector> sinkCall)

--- a/core/src/main/java/com/twitter/elephantbird/mapreduce/io/BinaryBlockReader.java
+++ b/core/src/main/java/com/twitter/elephantbird/mapreduce/io/BinaryBlockReader.java
@@ -128,7 +128,9 @@ public abstract class BinaryBlockReader<M> {
     }
 
     int blockSize = readInt();
-    LOG.debug("BlockReader: found sync point, next block has size " + blockSize);
+    if(LOG.isDebugEnabled()) {
+      LOG.debug("BlockReader: found sync point, next block has size " + blockSize);
+    }
     if (blockSize < 0) {
       LOG.debug("ProtobufReader: reading size after sync point eof");
       // EOF if the size cannot be read.


### PR DESCRIPTION
Use a thread pool for reading lzo indexes can cut launch time for a job from several minutes to the low seconds. 