### PR TITLE
Fix NPE when iterating over an input split in CompositeRecordReader.java

### DIFF
--- a/core/src/main/java/com/twitter/elephantbird/mapreduce/input/combine/CompositeRecordReader.java
+++ b/core/src/main/java/com/twitter/elephantbird/mapreduce/input/combine/CompositeRecordReader.java
@@ -171,8 +171,22 @@ public class CompositeRecordReader<K, V> extends RecordReader<K, V>
 
   @Override
   public void setKeyValue(K key, V value) {
-    ((MapredInputFormatCompatible) currentRecordReader).setKeyValue(key, value);
-    this.key = key;
-    this.value = value;
+    if (currentRecordReader == null) {
+      try {
+        if (!nextKeyValue()) {
+          throw new RuntimeException("No more valid record readers found");
+        }
+
+      } catch (IOException e) {
+        throw new RuntimeException(e);
+      } catch (InterruptedException e) {
+        throw new RuntimeException(e);
+      }
+    }
+    if (currentRecordReader != null) {
+      ((MapredInputFormatCompatible) currentRecordReader).setKeyValue(key, value);
+      this.key = key;
+      this.value = value;
+    }
   }
 }


### PR DESCRIPTION
When iterating over input splits via DeprecatedInputFormatWrapper, DeprecatedInputFormatWrapper.java always calls mifcReader.setKeyValue(key, value) before nextValue is invoked which can call through to setKeyValue in CompositeRecordReader.java. setKeyValue requires that the currentRecordReader instance be non-null; however currentRecordReader is set to null in line 113 at the end of every input split, leading to an NPE with the next call to setKeyValue after the end of an input split. 

This patch address the situation by having the setKeyValue method doing a null check for currentRecordReader and in the case it is null, invoking nextKeyValue to see if there are any more elements to be found 
