### PR TITLE
revert InputStream usage in BinaryBlockReader

### DIFF
--- a/core/src/main/java/com/twitter/elephantbird/mapreduce/io/BinaryBlockReader.java
+++ b/core/src/main/java/com/twitter/elephantbird/mapreduce/io/BinaryBlockReader.java
@@ -145,15 +145,16 @@ public class BinaryBlockReader<M> {
       // EOF if the size cannot be read.
       return null;
     }
-    byte[] byteArray = new byte[blockSize];
-    IOUtils.readFully(in_, byteArray, 0, blockSize);
 
     if (skipIfStartingOnBoundary && skipped == Protobufs.KNOWN_GOOD_POSITION_MARKER.length) {
       // skip the current current block
+      in_.skip(blockSize);
       return parseNextBlock(false);
     }
 
-    SerializedBlock block = SerializedBlock.parseFrom(byteArray);
+    SerializedBlock block = SerializedBlock.parseFrom(
+      new BoundedInputStream(in_, blockSize),
+      blockSize);
 
     curBlobs_ = block.getProtoBlobs();
     numLeftToReadThisBlock_ = curBlobs_.size();

--- a/core/src/main/java/com/twitter/elephantbird/mapreduce/io/BinaryBlockReader.java
+++ b/core/src/main/java/com/twitter/elephantbird/mapreduce/io/BinaryBlockReader.java
@@ -145,14 +145,15 @@ public class BinaryBlockReader<M> {
       // EOF if the size cannot be read.
       return null;
     }
+    byte[] byteArray = new byte[blockSize];
+    IOUtils.readFully(in_, byteArray, 0, blockSize);
 
     if (skipIfStartingOnBoundary && skipped == Protobufs.KNOWN_GOOD_POSITION_MARKER.length) {
       // skip the current current block
-      in_.skip(blockSize);
       return parseNextBlock(false);
     }
 
-    SerializedBlock block = SerializedBlock.parseFrom(new BoundedInputStream(in_, blockSize));
+    SerializedBlock block = SerializedBlock.parseFrom(byteArray);
 
     curBlobs_ = block.getProtoBlobs();
     numLeftToReadThisBlock_ = curBlobs_.size();

--- a/core/src/main/java/com/twitter/elephantbird/mapreduce/io/SerializedBlock.java
+++ b/core/src/main/java/com/twitter/elephantbird/mapreduce/io/SerializedBlock.java
@@ -73,16 +73,6 @@ public class SerializedBlock {
             .build());
   }
 
-  public static SerializedBlock parseFrom(InputStream in)
-                                          throws InvalidProtocolBufferException, IOException {
-    // note this reads the entire input stream so it should
-    // be bounded by the caller already if required
-    return new SerializedBlock(
-        DynamicMessage.newBuilder(messageDescriptor)
-            .mergeFrom(in)
-            .build());
-  }
-
   public static SerializedBlock parseFrom(byte[] messageBuffer)
                                           throws InvalidProtocolBufferException {
     return new SerializedBlock(

--- a/core/src/main/java/com/twitter/elephantbird/mapreduce/io/SerializedBlock.java
+++ b/core/src/main/java/com/twitter/elephantbird/mapreduce/io/SerializedBlock.java
@@ -74,14 +74,6 @@ public class SerializedBlock {
             .build());
   }
 
-  public static SerializedBlock parseFrom(byte[] messageBuffer)
-                                          throws InvalidProtocolBufferException {
-    return new SerializedBlock(
-        DynamicMessage.newBuilder(messageDescriptor)
-            .mergeFrom(messageBuffer)
-            .build());
-  }
-
   public static SerializedBlock parseFrom(InputStream in, int maxSize)
                                           throws InvalidProtocolBufferException, IOException {
     // create a CodedInputStream so that protobuf can enforce the configured max size
@@ -93,6 +85,14 @@ public class SerializedBlock {
     // verify we've read to the end
     codedInput.checkLastTagWas(0);
     return new SerializedBlock(messageBuilder.build());
+  }
+
+  public static SerializedBlock parseFrom(byte[] messageBuffer)
+                                          throws InvalidProtocolBufferException {
+    return new SerializedBlock(
+        DynamicMessage.newBuilder(messageDescriptor)
+            .mergeFrom(messageBuffer)
+            .build());
   }
 
   private static final Descriptors.Descriptor messageDescriptor;


### PR DESCRIPTION
Reverts one part of the changes made in https://github.com/twitter/elephant-bird/pull/439 that pass an `InputStream` to protobuf's `DynamicMessage` builder instead of a byte array. The builder wraps InputStream with a `CodedInputStream` which enforces a max size for the records that are read.

- http://grepcode.com/file/repo1.maven.org/maven2/com.google.protobuf/protobuf-java/2.4.1/com/google/protobuf/AbstractMessageLite.java#AbstractMessageLite.Builder.mergeFrom%28java.io.InputStream%29
- http://grepcode.com/file/repo1.maven.org/maven2/com.google.protobuf/protobuf-java/2.4.1/com/google/protobuf/CodedInputStream.java#CodedInputStream.setSizeLimit%28int%29

This fails for records that exceed 64MB, the default max size.
```
2015-05-13 04:55:16,261 WARN [main] org.apache.hadoop.mapred.YarnChild: Exception running child : com.google.protobuf.InvalidProtocolBufferException: Protocol message was too large.  May be malicious.  Use CodedInputStream.setSizeLimit() to increase the size limit.
	at com.google.protobuf.InvalidProtocolBufferException.sizeLimitExceeded(InvalidProtocolBufferException.java:110)
	at com.google.protobuf.CodedInputStream.refillBuffer(CodedInputStream.java:755)
	at com.google.protobuf.CodedInputStream.isAtEnd(CodedInputStream.java:701)
	at com.google.protobuf.CodedInputStream.readTag(CodedInputStream.java:99)
	at com.google.protobuf.AbstractMessage$Builder.mergeFrom(AbstractMessage.java:348)
	at com.google.protobuf.AbstractMessage$Builder.mergeFrom(AbstractMessage.java:337)
	at com.google.protobuf.AbstractMessage$Builder.mergeFrom(AbstractMessage.java:267)
	at com.google.protobuf.AbstractMessageLite$Builder.mergeFrom(AbstractMessageLite.java:210)
	at com.google.protobuf.AbstractMessage$Builder.mergeFrom(AbstractMessage.java:904)
	at com.twitter.elephantbird.mapreduce.io.SerializedBlock.parseFrom(SerializedBlock.java:80)
	at com.twitter.elephantbird.mapreduce.io.BinaryBlockReader.parseNextBlock(BinaryBlockReader.java:155)
	at com.twitter.elephantbird.mapreduce.input.LzoBinaryBlockRecordReader.skipToNextSyncPoint(LzoBinaryBlockRecordReader.java:106)
	at com.twitter.elephantbird.mapreduce.input.LzoRecordReader.initialize(LzoRecordReader.java:101)
	at com.twitter.elephantbird.mapreduce.input.LzoBinaryBlockRecordReader.initialize(LzoBinaryBlockRecordReader.java:95)
	at com.twitter.elephantbird.mapred.input.DeprecatedInputFormatWrapper$RecordReaderWrapper.<init>(DeprecatedInputFormatWrapper.java:257)
	at com.twitter.elephantbird.mapred.input.DeprecatedInputFormatWrapper.getRecordReader(DeprecatedInputFormatWrapper.java:121)
	at cascading.tap.hadoop.io.MultiInputFormat$1.operate(MultiInputFormat.java:253)
	at cascading.tap.hadoop.io.MultiInputFormat$1.operate(MultiInputFormat.java:248)
	at cascading.util.Util.retry(Util.java:762)
	at cascading.tap.hadoop.io.MultiInputFormat.getRecordReader(MultiInputFormat.java:247)
	at org.apache.hadoop.mapred.MapTask$TrackedRecordReader.<init>(MapTask.java:168)
	at org.apache.hadoop.mapred.MapTask.runOldMapper(MapTask.java:409)
	at org.apache.hadoop.mapred.MapTask.run(MapTask.java:342)
	at org.apache.hadoop.mapred.YarnChild$2.run(YarnChild.java:179)
	at java.security.AccessController.doPrivileged(Native Method)
	at javax.security.auth.Subject.doAs(Subject.java:415)
	at org.apache.hadoop.security.UserGroupInformation.doAs(UserGroupInformation.java:1565)
	at org.apache.hadoop.mapred.YarnChild.main(YarnChild.java:174)
```