### PR TITLE
Changed  byteStream.getCount() to byteStream.getLength()

### DIFF
--- a/rcfile/src/main/java/com/twitter/elephantbird/pig/store/RCFilePigStorage.java
+++ b/rcfile/src/main/java/com/twitter/elephantbird/pig/store/RCFilePigStorage.java
@@ -207,8 +207,8 @@ public class RCFilePigStorage extends PigStorage {
       StorageUtil.putField(byteStream, t.get(i));
       colValRefs[i].set(byteStream.getData(),
                         startPos,
-                        byteStream.getCount() - startPos);
-       startPos = byteStream.getCount();
+                        byteStream.getLength() - startPos);
+       startPos = byteStream.getLength();
     }
 
     try {


### PR DESCRIPTION
 so that RCFilePigStorage works with hive 0.14 (and is backwards compatible with previous versions)

Because 'public int getCount()' was removed from org.apache.hadoop.hive.serde2.ByteStream.Output in hive 0.14, and getLength() is available from the parent class.

   See:

   https://groups.google.com/forum/#!msg/elephantbird-dev/jNPK7p_QaNs/XshS_OLXNogJ
   https://issues.apache.org/jira/browse/PIG-3949
   https://issues.apache.org/jira/browse/HIVE-6430
   https://issues.apache.org/jira/secure/attachment/12642763/HIVE-6430.12.patch

Hive 0.13:
http://svn.apache.org/repos/asf/hive/branches/branch-0.13/serde/src/java/org/apache/hadoop/hive/serde2/ByteStream.java

Hive 0.14:
http://svn.apache.org/repos/asf/hive/branches/branch-0.14/serde/src/java/org/apache/hadoop/hive/serde2/ByteStream.java
