### PR TITLE
Add container size check in ThriftBinaryProtocol

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -58,6 +58,11 @@
       <artifactId>junit</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.easymock</groupId>
+      <artifactId>easymock</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>ant</groupId>
       <artifactId>ant</artifactId>
     </dependency>

--- a/core/src/main/java/com/twitter/elephantbird/thrift/ThriftBinaryProtocol.java
+++ b/core/src/main/java/com/twitter/elephantbird/thrift/ThriftBinaryProtocol.java
@@ -96,7 +96,7 @@ public class ThriftBinaryProtocol extends TBinaryProtocol {
     }
     if (checkReadLength_) {
       if ((readLength_ - size) < 0) {
-        throw new TProtocolException("Remaining message length is " + readLength_ + " but container size is at least: " + size);
+        throw new TProtocolException("Remaining message length is " + readLength_ + " but container size in underlying TTransport is set to at least: " + size);
       }
     }
   }

--- a/core/src/main/java/com/twitter/elephantbird/thrift/ThriftBinaryProtocol.java
+++ b/core/src/main/java/com/twitter/elephantbird/thrift/ThriftBinaryProtocol.java
@@ -5,6 +5,7 @@ import org.apache.thrift.protocol.TBinaryProtocol;
 import org.apache.thrift.protocol.TList;
 import org.apache.thrift.protocol.TMap;
 import org.apache.thrift.protocol.TProtocol;
+import org.apache.thrift.protocol.TProtocolException;
 import org.apache.thrift.protocol.TProtocolFactory;
 import org.apache.thrift.protocol.TSet;
 import org.apache.thrift.protocol.TType;
@@ -58,6 +59,7 @@ public class ThriftBinaryProtocol extends TBinaryProtocol {
   @Override
   public TMap readMapBegin() throws TException {
     TMap map = super.readMapBegin();
+    checkContainerSize(map.size);
     checkContainerElemType(map.keyType);
     checkContainerElemType(map.valueType);
     return map;
@@ -66,6 +68,7 @@ public class ThriftBinaryProtocol extends TBinaryProtocol {
   @Override
   public TList readListBegin() throws TException {
     TList list = super.readListBegin();
+    checkContainerSize(list.size);
     checkContainerElemType(list.elemType);
     return list;
   }
@@ -73,8 +76,29 @@ public class ThriftBinaryProtocol extends TBinaryProtocol {
   @Override
   public TSet readSetBegin() throws TException {
     TSet set = super.readSetBegin();
+    checkContainerSize(set.size);
     checkContainerElemType(set.elemType);
     return set;
+  }
+
+ /**
+   * Check if the container size if valid.
+   *
+   * NOTE: This assumes that the elements are one byte each.
+   * So this does not catch all cases, but does increase the chances of
+   * handling malformed lengths when the number of remaining bytes in
+   * the underlying Transport is clearly less than the container size
+   * that the Transport provides.
+   */
+  protected void checkContainerSize(int size) throws TProtocolException {
+    if (size < 0) {
+      throw new TProtocolException("Negative container size: " + size);
+    }
+    if (checkReadLength_) {
+      if ((readLength_ - size) < 0) {
+        throw new TProtocolException("Remaining message length is " + readLength_ + " but container size is at least: " + size);
+      }
+    }
   }
 
   public static class Factory implements TProtocolFactory {

--- a/core/src/test/java/com/twitter/elephantbird/thrift/TestThriftBinaryProtocol.java
+++ b/core/src/test/java/com/twitter/elephantbird/thrift/TestThriftBinaryProtocol.java
@@ -1,0 +1,181 @@
+package com.twitter.elephantbird.thrift;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+
+import org.junit.Test;
+
+import org.apache.thrift.TException;
+import org.apache.thrift.protocol.TProtocolException;
+import org.apache.thrift.protocol.TType;
+import org.apache.thrift.transport.TTransport;
+import org.apache.thrift.transport.TTransportException;
+
+// mock transport for Set and List container types
+class TestTransport extends TTransport {
+
+  protected int containerSize;
+
+  protected int readAllCalls = 0;
+
+  // returns the supplied int as the container size
+  // when called by ThriftBinaryProtocol
+  public TestTransport(int containerSize) {
+    this.containerSize = containerSize;
+  }
+
+  @Override
+  public void close() {}
+
+  @Override
+  public boolean isOpen() { return true; }
+
+  @Override
+  public void open() throws TTransportException {}
+
+  // should not be invoked in unit tests
+  public int read(byte[] buf, int off, int len) throws TTransportException {
+    throw new IllegalStateException();
+  }
+
+  // helper method to set container size correctly in the supplied byte array
+  protected void setContainerSize(byte[] buf, int n) {
+    byte[] b = ByteBuffer.allocate(4).putInt(n).array();
+    for (int i = 0; i < 4; i++) {
+      buf[i] = b[i];
+    }
+  }
+
+  @Override
+  public int readAll(byte[] buf, int off, int len) throws TTransportException {
+    int bytesWritten = 0;
+    switch(++readAllCalls) {
+      case 1:
+        // first call, set data type
+        buf[0] = TType.BYTE;
+        bytesWritten = 1;
+        break;
+      case 2:
+        // second call, set container size
+        setContainerSize(buf, containerSize);
+        bytesWritten = 4;
+        break;
+      default:
+        // only two calls are needed for List and Set metadata
+        throw new IllegalStateException();
+    }
+    return bytesWritten;
+  }
+
+  @Override
+  public void write(byte[] buf, int off, int len) throws TTransportException {}
+}
+
+// mock transport for Map container type
+class TestMapTransport extends TestTransport {
+
+  public TestMapTransport(int containerSize) {
+    super(containerSize);
+  }
+
+  @Override
+  public int readAll(byte[] buf, int off, int len) throws TTransportException {
+    int bytesWritten = 0;
+    switch(++readAllCalls) {
+      case 1:
+        // first call, set key type
+        buf[0] = TType.BYTE;
+        bytesWritten = 1;
+        break;
+      case 2:
+        // second call, set value type
+        buf[0] = TType.BYTE;
+        bytesWritten = 1;
+        break;
+      case 3:
+        // third call, set container size
+        setContainerSize(buf, containerSize);
+        bytesWritten = 4;
+        break;
+      default:
+        // only three calls are needed for Map metadata 
+        throw new IllegalStateException();
+    }
+    return bytesWritten;
+  }
+}
+
+public class TestThriftBinaryProtocol {
+
+  int METADATA_BYTES = 5; // type(1) + size(4)
+  int MAP_METADATA_BYTES = 6; // key type(1) + value type(1) + size(4)
+
+  @Test
+  public void testCheckContainerSizeValid() throws TException {
+    // any non-negative value is considered valid when checkReadLength is not enabled
+    ThriftBinaryProtocol protocol;
+    protocol = new ThriftBinaryProtocol(new TestTransport(3));
+    protocol.readListBegin();
+    protocol = new ThriftBinaryProtocol(new TestTransport(3));
+    protocol.readSetBegin();
+    protocol = new ThriftBinaryProtocol(new TestMapTransport(3));
+    protocol.readMapBegin();
+  }
+
+  @Test
+  public void testCheckContainerSizeValidWhenCheckReadLength() throws TException {
+    ThriftBinaryProtocol protocol;
+    protocol = new ThriftBinaryProtocol(new TestTransport(3));
+    protocol.setReadLength(METADATA_BYTES + 3);
+    protocol.readListBegin();
+    protocol = new ThriftBinaryProtocol(new TestTransport(3));
+    protocol.setReadLength(METADATA_BYTES + 3);
+    protocol.readSetBegin();
+    protocol = new ThriftBinaryProtocol(new TestMapTransport(3));
+    protocol.setReadLength(MAP_METADATA_BYTES + 3);
+    protocol.readMapBegin();
+  }
+
+  @Test(expected=TProtocolException.class)
+  public void testCheckListContainerSizeInvalid() throws TException {
+    // any negative value is considered invalid when checkReadLength is not enabled
+    ThriftBinaryProtocol protocol = new ThriftBinaryProtocol(new TestTransport(-1));
+    protocol.readListBegin();
+  }
+
+  @Test(expected=TProtocolException.class)
+  public void testCheckSetContainerSizeInvalid() throws TException {
+    ThriftBinaryProtocol protocol = new ThriftBinaryProtocol(new TestTransport(-1));
+    protocol.readSetBegin();
+  }
+
+  @Test(expected=TProtocolException.class)
+  public void testCheckMapContainerSizeInvalid() throws TException {
+    ThriftBinaryProtocol protocol = new ThriftBinaryProtocol(new TestMapTransport(-1));
+    protocol.readMapBegin();
+  }
+
+  @Test(expected=TProtocolException.class)
+  public void testCheckListContainerSizeInvalidWhenCheckReadLength() throws TException {
+    ThriftBinaryProtocol protocol = new ThriftBinaryProtocol(new TestTransport(400));
+    protocol.setReadLength(METADATA_BYTES + 3);
+    // this throws because size returned by Transport (400) > size per readLength (3)
+    protocol.readListBegin();
+  }
+
+  @Test(expected=TProtocolException.class)
+  public void testCheckSetContainerSizeInvalidWhenCheckReadLength() throws TException {
+    ThriftBinaryProtocol protocol = new ThriftBinaryProtocol(new TestTransport(400));
+    // this throws because size returned by Transport (400) > size per readLength (3)
+    protocol.setReadLength(METADATA_BYTES + 3);
+    protocol.readSetBegin();
+  }
+
+  @Test(expected=TProtocolException.class)
+  public void testCheckMapContainerSizeInvalidWhenCheckReadLength() throws TException {
+    ThriftBinaryProtocol protocol = new ThriftBinaryProtocol(new TestMapTransport(400));
+    // this throws because size returned by Transport (400) > size per readLength (3)
+    protocol.setReadLength(MAP_METADATA_BYTES + 3);
+    protocol.readMapBegin();
+  }
+}

--- a/core/src/test/java/com/twitter/elephantbird/thrift/TestThriftBinaryProtocol.java
+++ b/core/src/test/java/com/twitter/elephantbird/thrift/TestThriftBinaryProtocol.java
@@ -17,6 +17,7 @@ import static org.easymock.EasyMock.createStrictMock;
 import static org.easymock.EasyMock.expect;
 import static org.easymock.EasyMock.isA;
 import static org.easymock.EasyMock.replay;
+import static org.easymock.EasyMock.verify;
 
 public class TestThriftBinaryProtocol {
 
@@ -119,16 +120,19 @@ public class TestThriftBinaryProtocol {
     replay(transport);
     protocol = new ThriftBinaryProtocol(transport);
     protocol.readListBegin();
+    verify(transport);
 
     transport = getMockTransport(3);
     replay(transport);
     protocol = new ThriftBinaryProtocol(transport);
     protocol.readSetBegin();
+    verify(transport);
 
     transport = getMockMapTransport(3);
     replay(transport);
     protocol = new ThriftBinaryProtocol(transport);
     protocol.readMapBegin();
+    verify(transport);
   }
 
   @Test
@@ -141,18 +145,21 @@ public class TestThriftBinaryProtocol {
     protocol = new ThriftBinaryProtocol(transport);
     protocol.setReadLength(METADATA_BYTES + 3);
     protocol.readListBegin();
+    verify(transport);
 
     transport = getMockTransport(3);
     replay(transport);
     protocol = new ThriftBinaryProtocol(transport);
     protocol.setReadLength(METADATA_BYTES + 3);
     protocol.readSetBegin();
+    verify(transport);
 
     transport = getMockMapTransport(3);
     replay(transport);
     protocol = new ThriftBinaryProtocol(transport);
     protocol.setReadLength(MAP_METADATA_BYTES + 3);
     protocol.readMapBegin();
+    verify(transport);
   }
 
   @Test(expected=TProtocolException.class)
@@ -162,6 +169,7 @@ public class TestThriftBinaryProtocol {
     replay(transport);
     ThriftBinaryProtocol protocol = new ThriftBinaryProtocol(transport);
     protocol.readListBegin();
+    verify(transport);
   }
 
   @Test(expected=TProtocolException.class)
@@ -170,6 +178,7 @@ public class TestThriftBinaryProtocol {
     replay(transport);
     ThriftBinaryProtocol protocol = new ThriftBinaryProtocol(transport);
     protocol.readSetBegin();
+    verify(transport);
   }
 
   @Test(expected=TProtocolException.class)
@@ -178,6 +187,7 @@ public class TestThriftBinaryProtocol {
     replay(transport);
     ThriftBinaryProtocol protocol = new ThriftBinaryProtocol(transport);
     protocol.readMapBegin();
+    verify(transport);
   }
 
   @Test(expected=TProtocolException.class)
@@ -188,6 +198,7 @@ public class TestThriftBinaryProtocol {
     protocol.setReadLength(METADATA_BYTES + 3);
     // this throws because size returned by Transport (400) > size per readLength (3)
     protocol.readListBegin();
+    verify(transport);
   }
 
   @Test(expected=TProtocolException.class)
@@ -198,6 +209,7 @@ public class TestThriftBinaryProtocol {
     // this throws because size returned by Transport (400) > size per readLength (3)
     protocol.setReadLength(METADATA_BYTES + 3);
     protocol.readSetBegin();
+    verify(transport);
   }
 
   @Test(expected=TProtocolException.class)
@@ -208,5 +220,6 @@ public class TestThriftBinaryProtocol {
     // this throws because size returned by Transport (400) > size per readLength (3)
     protocol.setReadLength(MAP_METADATA_BYTES + 3);
     protocol.readMapBegin();
+    verify(transport);
   }
 }


### PR DESCRIPTION
The read length check is currently enabled in ThriftBinaryDeserializer.

https://github.com/twitter/elephant-bird/blob/master/core/src/main/java/com/twitter/elephantbird/thrift/ThriftBinaryDeserializer.java#L46

However, we do not check the container sizes against this. As a result, invalid container sizes returned by the underlying Transport can cause OutOfMemoryExceptions. This change adds a check on the container size before we start reading any elements.