### PR TITLE
Support Thrift 0.9.x

### DIFF
--- a/core/src/main/java/com/twitter/elephantbird/thrift/ThriftBinaryDeserializer.java
+++ b/core/src/main/java/com/twitter/elephantbird/thrift/ThriftBinaryDeserializer.java
@@ -29,7 +29,7 @@ public class ThriftBinaryDeserializer extends TDeserializer {
 
   // use protocol and transport directly instead of using ones in TDeserializer
   private final TMemoryInputTransport trans = new TMemoryInputTransport();
-  private final TBinaryProtocol protocol = new ThriftBinaryProtocol(trans);
+  private final ThriftBinaryProtocol protocol = new ThriftBinaryProtocol(trans);
 
   public ThriftBinaryDeserializer() {
     super(new ThriftBinaryProtocol.Factory());
@@ -45,7 +45,7 @@ public class ThriftBinaryDeserializer extends TDeserializer {
    */
   public void deserialize(TBase base, byte[] bytes, int offset, int len) throws TException {
     protocol.reset();
-    protocol.setReadLength(len); // reduces OutOfMemoryError exceptions
+    protocol.setMaxReadLength(len); // reduces OutOfMemoryError exceptions
     trans.reset(bytes, offset, len);
     base.read(protocol);
   }

--- a/core/src/main/java/com/twitter/elephantbird/thrift/ThriftBinaryProtocol.java
+++ b/core/src/main/java/com/twitter/elephantbird/thrift/ThriftBinaryProtocol.java
@@ -36,7 +36,8 @@ public class ThriftBinaryProtocol extends TBinaryProtocol {
     SetReadLengthMethod = method;
   }
 
-  // Thrift 0.9.1 doees not support setReadLength(). This get around that.
+  // Thrift 0.9.1 does not support setReadLength(). Store it here so that it works
+  // for thrift 0.9.x as well
   protected int maxReadLength = -1;
 
   public ThriftBinaryProtocol(TTransport trans) {

--- a/core/src/test/java/com/twitter/elephantbird/thrift/TestThriftBinaryProtocol.java
+++ b/core/src/test/java/com/twitter/elephantbird/thrift/TestThriftBinaryProtocol.java
@@ -195,7 +195,7 @@ public class TestThriftBinaryProtocol {
     TTransport transport = getMockTransport(400);
     replay(transport);
     ThriftBinaryProtocol protocol = new ThriftBinaryProtocol(transport);
-    protocol.setReadLength(METADATA_BYTES + 3);
+    protocol.setMaxReadLength(METADATA_BYTES + 3);
     // this throws because size returned by Transport (400) > size per readLength (3)
     protocol.readListBegin();
     verify(transport);
@@ -207,7 +207,7 @@ public class TestThriftBinaryProtocol {
     replay(transport);
     ThriftBinaryProtocol protocol = new ThriftBinaryProtocol(transport);
     // this throws because size returned by Transport (400) > size per readLength (3)
-    protocol.setReadLength(METADATA_BYTES + 3);
+    protocol.setMaxReadLength(METADATA_BYTES + 3);
     protocol.readSetBegin();
     verify(transport);
   }
@@ -218,7 +218,7 @@ public class TestThriftBinaryProtocol {
     replay(transport);
     ThriftBinaryProtocol protocol = new ThriftBinaryProtocol(transport);
     // this throws because size returned by Transport (400) > size per readLength (3)
-    protocol.setReadLength(MAP_METADATA_BYTES + 3);
+    protocol.setMaxReadLength(MAP_METADATA_BYTES + 3);
     protocol.readMapBegin();
     verify(transport);
   }


### PR DESCRIPTION
This is an alternate fix for pull #455 to suppor Thrift 0.9.x. at runtime. 
This fix detects at runtime if the 'setReadLenght()' method exists, and invokes it only when it is available.

[ok, just noticed #455 is merged already. will send the anyway]