### PR TITLE
Follow-up fix for cascading3

### DIFF
--- a/cascading3/src/main/java/com/twitter/elephantbird/cascading3/scheme/CombinedSequenceFile.java
+++ b/cascading3/src/main/java/com/twitter/elephantbird/cascading3/scheme/CombinedSequenceFile.java
@@ -71,7 +71,7 @@ public class CombinedSequenceFile extends SequenceFile {
     // in order to use the EB combiner we must wrap the mapred SequenceFileInputFormat
     // with the MapReduceInputFormatWrapper and then wrap it in the DelegateCombineFileInputFormat
     MapReduceInputFormatWrapper.setWrappedInputFormat(SequenceFileInputFormat.class, conf);
-    DelegateCombineFileInputFormat.setDelegateInputFormatHadoop2(conf, MapReduceInputFormatWrapper.class);
+    DelegateCombineFileInputFormat.setDelegateInputFormat(conf, MapReduceInputFormatWrapper.class);
   }
 
   @Override

--- a/cascading3/src/main/java/com/twitter/elephantbird/cascading3/scheme/LzoByteArrayScheme.java
+++ b/cascading3/src/main/java/com/twitter/elephantbird/cascading3/scheme/LzoByteArrayScheme.java
@@ -51,6 +51,6 @@ public class LzoByteArrayScheme extends LzoBinaryScheme<byte[], RawBytesWritable
   @Override public void sinkConfInit(FlowProcess<? extends Configuration> fp,
       Tap<Configuration, RecordReader, OutputCollector> tap,
       Configuration conf) {
-    conf.setClass("mapreduce.outputformat.class", LzoBinaryBlockOutputFormat.class, OutputFormat.class);
+    DeprecatedOutputFormatWrapper.setOutputFormat(LzoBinaryBlockOutputFormat.class, conf);
   }
 }

--- a/cascading3/src/main/java/com/twitter/elephantbird/cascading3/scheme/LzoByteArrayScheme.java
+++ b/cascading3/src/main/java/com/twitter/elephantbird/cascading3/scheme/LzoByteArrayScheme.java
@@ -45,7 +45,7 @@ public class LzoByteArrayScheme extends LzoBinaryScheme<byte[], RawBytesWritable
       Tap<Configuration, RecordReader, OutputCollector> tap,
       Configuration conf) {
     MultiInputFormat.setClassConf(byte[].class, conf);
-    DelegateCombineFileInputFormat.setDelegateInputFormatHadoop2(conf, MultiInputFormat.class);
+    DelegateCombineFileInputFormat.setDelegateInputFormat(conf, MultiInputFormat.class);
   }
 
   @Override public void sinkConfInit(FlowProcess<? extends Configuration> fp,

--- a/cascading3/src/main/java/com/twitter/elephantbird/cascading3/scheme/LzoProtobufScheme.java
+++ b/cascading3/src/main/java/com/twitter/elephantbird/cascading3/scheme/LzoProtobufScheme.java
@@ -48,6 +48,6 @@ public class LzoProtobufScheme<M extends Message> extends
   @Override
   public void sourceConfInit(FlowProcess<? extends Configuration> hfp, Tap<Configuration, RecordReader, OutputCollector> tap, Configuration conf) {
     MultiInputFormat.setClassConf(protoClass, conf);
-    DelegateCombineFileInputFormat.setDelegateInputFormatHadoop2(conf, MultiInputFormat.class);
+    DelegateCombineFileInputFormat.setDelegateInputFormat(conf, MultiInputFormat.class);
   }
 }

--- a/cascading3/src/main/java/com/twitter/elephantbird/cascading3/scheme/LzoProtobufScheme.java
+++ b/cascading3/src/main/java/com/twitter/elephantbird/cascading3/scheme/LzoProtobufScheme.java
@@ -42,7 +42,7 @@ public class LzoProtobufScheme<M extends Message> extends
   @Override
   public void sinkConfInit(FlowProcess<? extends Configuration> hfp, Tap<Configuration, RecordReader, OutputCollector> tap, Configuration conf) {
     LzoProtobufBlockOutputFormat.setClassConf(protoClass, conf);
-    conf.setClass("mapreduce.outputformat.class", LzoProtobufBlockOutputFormat.class, OutputFormat.class);
+    DeprecatedOutputFormatWrapper.setOutputFormat(LzoProtobufBlockOutputFormat.class, conf);
   }
 
   @Override

--- a/cascading3/src/main/java/com/twitter/elephantbird/cascading3/scheme/LzoTextDelimited.java
+++ b/cascading3/src/main/java/com/twitter/elephantbird/cascading3/scheme/LzoTextDelimited.java
@@ -1,7 +1,7 @@
 package com.twitter.elephantbird.cascading3.scheme;
 
+import com.twitter.elephantbird.mapred.input.DeprecatedInputFormatWrapper;
 import com.twitter.elephantbird.mapreduce.input.LzoTextInputFormat;
-import com.twitter.elephantbird.mapreduce.input.combine.DelegateCombineFileInputFormat;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.mapred.JobConf;
 import org.apache.hadoop.mapred.OutputCollector;
@@ -74,7 +74,7 @@ public class LzoTextDelimited extends TextDelimited {
 
   @Override
   public void sourceConfInit(FlowProcess<? extends Configuration> flowProcess, Tap<Configuration, RecordReader, OutputCollector> tap, Configuration conf ) {
-    conf.setClass("mapreduce.inputformat.class", LzoTextInputFormat.class, InputFormat.class);
+    DeprecatedInputFormatWrapper.setInputFormat(LzoTextInputFormat.class, conf);
   }
 
   @Override

--- a/cascading3/src/main/java/com/twitter/elephantbird/cascading3/scheme/LzoTextDelimited.java
+++ b/cascading3/src/main/java/com/twitter/elephantbird/cascading3/scheme/LzoTextDelimited.java
@@ -4,10 +4,10 @@ import com.twitter.elephantbird.mapreduce.input.LzoTextInputFormat;
 import com.twitter.elephantbird.mapreduce.input.combine.DelegateCombineFileInputFormat;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.mapred.JobConf;
-import org.apache.hadoop.mapred.InputFormat;
 import org.apache.hadoop.mapred.OutputCollector;
 import org.apache.hadoop.mapred.OutputFormat;
 import org.apache.hadoop.mapred.RecordReader;
+import org.apache.hadoop.mapreduce.InputFormat;
 
 import com.twitter.elephantbird.mapred.output.DeprecatedLzoTextOutputFormat;
 
@@ -74,7 +74,7 @@ public class LzoTextDelimited extends TextDelimited {
 
   @Override
   public void sourceConfInit(FlowProcess<? extends Configuration> flowProcess, Tap<Configuration, RecordReader, OutputCollector> tap, Configuration conf ) {
-    conf.setClass("mapred.input.format.class", LzoTextInputFormat.class, InputFormat.class);
+    conf.setClass("mapreduce.inputformat.class", LzoTextInputFormat.class, InputFormat.class);
   }
 
   @Override

--- a/cascading3/src/main/java/com/twitter/elephantbird/cascading3/scheme/LzoTextLine.java
+++ b/cascading3/src/main/java/com/twitter/elephantbird/cascading3/scheme/LzoTextLine.java
@@ -1,7 +1,7 @@
 package com.twitter.elephantbird.cascading3.scheme;
 
+import com.twitter.elephantbird.mapred.input.DeprecatedInputFormatWrapper;
 import com.twitter.elephantbird.mapreduce.input.LzoTextInputFormat;
-import com.twitter.elephantbird.mapreduce.input.combine.DelegateCombineFileInputFormat;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.mapred.JobConf;
 import org.apache.hadoop.mapred.OutputCollector;
@@ -49,7 +49,7 @@ public class LzoTextLine extends TextLine {
 
   @Override
   public void sourceConfInit(FlowProcess<? extends Configuration> flowProcess, Tap<Configuration, RecordReader, OutputCollector> tap, Configuration conf ) {
-    conf.setClass("mapreduce.inputformat.class", LzoTextInputFormat.class, InputFormat.class);
+    DeprecatedInputFormatWrapper.setInputFormat(LzoTextInputFormat.class, conf);
   }
 
   @Override

--- a/cascading3/src/main/java/com/twitter/elephantbird/cascading3/scheme/LzoTextLine.java
+++ b/cascading3/src/main/java/com/twitter/elephantbird/cascading3/scheme/LzoTextLine.java
@@ -4,10 +4,10 @@ import com.twitter.elephantbird.mapreduce.input.LzoTextInputFormat;
 import com.twitter.elephantbird.mapreduce.input.combine.DelegateCombineFileInputFormat;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.mapred.JobConf;
-import org.apache.hadoop.mapred.InputFormat;
 import org.apache.hadoop.mapred.OutputCollector;
 import org.apache.hadoop.mapred.OutputFormat;
 import org.apache.hadoop.mapred.RecordReader;
+import org.apache.hadoop.mapreduce.InputFormat;
 
 import com.twitter.elephantbird.mapred.output.DeprecatedLzoTextOutputFormat;
 
@@ -49,7 +49,7 @@ public class LzoTextLine extends TextLine {
 
   @Override
   public void sourceConfInit(FlowProcess<? extends Configuration> flowProcess, Tap<Configuration, RecordReader, OutputCollector> tap, Configuration conf ) {
-    conf.setClass("mapred.input.format.class", LzoTextInputFormat.class, InputFormat.class);
+    conf.setClass("mapreduce.inputformat.class", LzoTextInputFormat.class, InputFormat.class);
   }
 
   @Override

--- a/cascading3/src/main/java/com/twitter/elephantbird/cascading3/scheme/LzoThriftScheme.java
+++ b/cascading3/src/main/java/com/twitter/elephantbird/cascading3/scheme/LzoThriftScheme.java
@@ -48,6 +48,6 @@ public class LzoThriftScheme<M extends TBase<?,?>> extends
   @Override
   public void sourceConfInit(FlowProcess<? extends Configuration> hfp, Tap<Configuration, RecordReader, OutputCollector> tap, Configuration conf) {
     MultiInputFormat.setClassConf(thriftClass, conf);
-    DelegateCombineFileInputFormat.setDelegateInputFormatHadoop2(conf, MultiInputFormat.class);
+    DelegateCombineFileInputFormat.setDelegateInputFormat(conf, MultiInputFormat.class);
   }
 }

--- a/cascading3/src/main/java/com/twitter/elephantbird/cascading3/scheme/LzoThriftScheme.java
+++ b/cascading3/src/main/java/com/twitter/elephantbird/cascading3/scheme/LzoThriftScheme.java
@@ -37,7 +37,7 @@ public class LzoThriftScheme<M extends TBase<?,?>> extends
   @Override
   public void sinkConfInit(FlowProcess<? extends Configuration> hfp, Tap<Configuration, RecordReader, OutputCollector> tap, Configuration conf) {
     LzoThriftBlockOutputFormat.setClassConf(thriftClass, conf);
-    conf.setClass("mapreduce.outputformat.class", LzoThriftBlockOutputFormat.class, OutputFormat.class);
+    DeprecatedOutputFormatWrapper.setOutputFormat(LzoThriftBlockOutputFormat.class, conf);
   }
 
   protected ThriftWritable<M> prepareBinaryWritable() {

--- a/cascading3/src/test/java/com/twitter/elephantbird/cascading3/scheme/TestCombinedSequenceFile.java
+++ b/cascading3/src/test/java/com/twitter/elephantbird/cascading3/scheme/TestCombinedSequenceFile.java
@@ -40,9 +40,9 @@ public class TestCombinedSequenceFile {
         conf.get(DelegateCombineFileInputFormat.COMBINED_INPUT_FORMAT_DELEGATE)
     );
     assertEquals(
-	"Delegate combiner should be set without any deprecated wrapper", 
+        "DeprecatedInputFormatWrapper should wrap Delegate combiner",
         "com.twitter.elephantbird.mapreduce.input.combine.DelegateCombineFileInputFormat",
-        conf.get("mapreduce.inputformat.class")
+        conf.get(DeprecatedInputFormatWrapper.CLASS_CONF_KEY)
     );
   }
 

--- a/core/src/main/java/com/twitter/elephantbird/mapred/input/DeprecatedInputFormatWrapper.java
+++ b/core/src/main/java/com/twitter/elephantbird/mapred/input/DeprecatedInputFormatWrapper.java
@@ -74,6 +74,14 @@ public class DeprecatedInputFormatWrapper<K, V> implements org.apache.hadoop.map
     HadoopUtils.setClassConf(jobConf, CLASS_CONF_KEY, realInputFormatClass);
   }
 
+  /**
+   * For cases where we need to set hadoop1 input format in a hadoop2 Configuration object.
+   */
+  public static void setInputFormat(Class<?> realInputFormatClass, Configuration conf) {
+    conf.setClass("mapred.input.format.class", DeprecatedInputFormatWrapper.class, org.apache.hadoop.mapred.InputFormat.class);
+    HadoopUtils.setClassConf(conf, CLASS_CONF_KEY, realInputFormatClass);
+  }
+
 	public static void setInputFormat(Class<?> realInputFormatClass, JobConf jobConf,
 			Class<? extends DeprecatedInputFormatValueCopier<?>> valueCopyClass) {
 		jobConf.setInputFormat(DeprecatedInputFormatWrapper.class);

--- a/core/src/main/java/com/twitter/elephantbird/mapred/output/DeprecatedOutputFormatWrapper.java
+++ b/core/src/main/java/com/twitter/elephantbird/mapred/output/DeprecatedOutputFormatWrapper.java
@@ -3,6 +3,7 @@ package com.twitter.elephantbird.mapred.output;
 import java.io.IOException;
 
 import com.twitter.elephantbird.util.HadoopCompat;
+import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.mapred.JobConf;
 import org.apache.hadoop.mapred.RecordWriter;
@@ -58,6 +59,14 @@ public class DeprecatedOutputFormatWrapper<K, V>
   public static void setOutputFormat(Class<?> realOutputFormatClass, JobConf jobConf) {
     jobConf.setOutputFormat(DeprecatedOutputFormatWrapper.class);
     HadoopUtils.setClassConf(jobConf, CLASS_CONF_KEY, realOutputFormatClass);
+  }
+
+  /**
+   * For cases where we need to set hadoop1 output format in a hadoop2 Configuration object.
+   */
+  public static void setOutputFormat(Class<?> realOutputFormatClass, Configuration conf) {
+    conf.setClass("mapred.output.format.class", DeprecatedOutputFormatWrapper.class, org.apache.hadoop.mapred.OutputFormat.class);
+    HadoopUtils.setClassConf(conf, CLASS_CONF_KEY, realOutputFormatClass);
   }
 
   @SuppressWarnings("unchecked")

--- a/core/src/main/java/com/twitter/elephantbird/mapreduce/input/combine/DelegateCombineFileInputFormat.java
+++ b/core/src/main/java/com/twitter/elephantbird/mapreduce/input/combine/DelegateCombineFileInputFormat.java
@@ -51,8 +51,13 @@ public class DelegateCombineFileInputFormat<K, V> extends FileInputFormat<K, V> 
     setCombinedInputFormatDelegate(jobConf, inputFormat);
   }
 
+  public static void setDelegateInputFormat(Configuration conf, Class<? extends InputFormat> inputFormat) {
+    DeprecatedInputFormatWrapper.setInputFormat(DelegateCombineFileInputFormat.class, conf);
+    setCombinedInputFormatDelegate(conf, inputFormat);
+  }
+
   public static void setDelegateInputFormatHadoop2(Configuration conf, Class<? extends InputFormat> inputFormat) {
-    conf.setClass("mapreduce.inputformat.class", DelegateCombineFileInputFormat.class, InputFormat.class); 
+    conf.setClass("mapreduce.inputformat.class", DelegateCombineFileInputFormat.class, InputFormat.class);
     setCombinedInputFormatDelegate(conf, inputFormat);
   }
 


### PR DESCRIPTION
This is a follow-up to https://github.com/twitter/elephant-bird/pull/463

This change adds a method for setting hadoop1 input format key via hadoop2 Configuration objects, and fixes the related Schemes.

In cascading3, Hfs and related taps have been moved to the hadoop2 api (Configuration objects). However, cascading's MultiInputFormat checks for hadoop1 config key for input formats:
https://github.com/cwensel/cascading/blob/wip-3.1/cascading-hadoop/src/main/shared-io/cascading/tap/hadoop/io/MultiInputFormat.java#L69

I've verified this fix with some test job runs at Twitter.