### PR TITLE
fix LzoBinaryBlockRecordReader bug: skip bad block rather than throws IOE

### DIFF
--- a/core/src/main/java/com/twitter/elephantbird/mapreduce/input/LzoBinaryBlockRecordReader.java
+++ b/core/src/main/java/com/twitter/elephantbird/mapreduce/input/LzoBinaryBlockRecordReader.java
@@ -136,8 +136,13 @@ public class LzoBinaryBlockRecordReader<M, W extends BinaryWritable<M>>
         // As a consequence of this, next split reader skips at least one byte
         // (i.e. skips either partial or full record at the beginning).
       }
-      byte[] byteArray = reader_.readNextProtoBytes();
-
+      byte[] byteArray = null;
+      try {
+        byteArray = reader_.readNextProtoBytes();
+      } catch (IOException ioe){
+        // catch IOE, rather than throw  it
+        LOG.error("Error reading split, skip it. ", ioe);
+      }
       if(byteArray == null) {
         return false;
       }


### PR DESCRIPTION
In some scenario, LzoThriftBlock file may be corrupt. For example, in our company, we consume kafka data and sink to HDFS as LzoThriftBlock format using a flink streaming job. If the job crash, the writing file may be corrupt. The mapreduce job reading the corrupt file will fail . 

Error logs are as follows: 

org.apache.hadoop.mapred.YarnChild: Exception running child : java.io.IOException: Premature EOF from inputStream
	at org.apache.hadoop.io.IOUtils.readFully(IOUtils.java:201)
	at com.twitter.elephantbird.mapreduce.io.BinaryBlockReader.parseNextBlock(BinaryBlockReader.java:145)
	at com.twitter.elephantbird.mapreduce.io.BinaryBlockReader.setupNewBlockIfNeeded(BinaryBlockReader.java:169)
	at com.twitter.elephantbird.mapreduce.io.BinaryBlockReader.readNextProtoBytes(BinaryBlockReader.java:87)
	at com.twitter.elephantbird.mapreduce.io.BinaryBlockReader.readNext(BinaryBlockReader.java:74)
	at com.twitter.elephantbird.mapreduce.input.LzoBinaryBlockRecordReader.nextKeyValue(LzoBinaryBlockRecordReader.java:138)
	at com.twitter.elephantbird.pig.load.LzoBaseLoadFunc.getNextBinaryValue(LzoBaseLoadFunc.java:108)
	at com.twitter.elephantbird.pig.load.ThriftPigLoader.getNext(ThriftPigLoader.java:48)
	at org.apache.pig.backend.hadoop.executionengine.mapReduceLayer.PigRecordReader.nextKeyValue(PigRecordReader.java:211)
	at org.apache.hadoop.mapred.MapTask$NewTrackingRecordReader.nextKeyValue(MapTask.java:556)
	at org.apache.hadoop.mapreduce.task.MapContextImpl.nextKeyValue(MapContextImpl.java:80)
	at org.apache.hadoop.mapreduce.lib.map.WrappedMapper$Context.nextKeyValue(WrappedMapper.java:91)
	at org.apache.hadoop.mapreduce.Mapper.run(Mapper.java:144)
	at org.apache.hadoop.mapred.MapTask.runNewMapper(MapTask.java:787)
	at org.apache.hadoop.mapred.MapTask.run(MapTask.java:341)
	at org.apache.hadoop.mapred.YarnChild$2.run(YarnChild.java:164)
	at java.security.AccessController.doPrivileged(Native Method)
	at javax.security.auth.Subject.doAs(Subject.java:422)
	at org.apache.hadoop.security.UserGroupInformation.doAs(UserGroupInformation.java:1693)
	at org.apache.hadoop.mapred.YarnChild.main(YarnChild.java:158)

The reason is the last block of the split is incomplete because of suddenly quit of the writing steam. I think this could be more tolerant，although the last block is corrupt, the preceding blocks of the split is OK. All we should do is skipping the corrupt block.