### PR TITLE
Make numRecordsPerBlock configurable

### DIFF
--- a/core/src/main/java/com/twitter/elephantbird/mapreduce/io/BinaryBlockWriter.java
+++ b/core/src/main/java/com/twitter/elephantbird/mapreduce/io/BinaryBlockWriter.java
@@ -9,11 +9,14 @@ import com.google.protobuf.ByteString;
 import com.google.protobuf.Message;
 import com.twitter.elephantbird.util.Protobufs;
 
+import org.apache.hadoop.conf.Configuration;
+
 /**
  * A class to write blocks of serialized objects.
  */
 public class BinaryBlockWriter<M> {
   protected static final int DEFAULT_NUM_RECORDS_PER_BLOCK = 100;
+  public static final String NUM_RECORDS_PER_BLOCK = "elephantbird.num.records.per.block";
 
   private final OutputStream out_;
   private final int numRecordsPerBlock_;
@@ -22,7 +25,11 @@ public class BinaryBlockWriter<M> {
   private int numRecordsWritten_ = 0;
   private List<ByteString> protoBlobs_;
 
-  protected BinaryBlockWriter(OutputStream out, Class<M> protoClass, BinaryConverter<M> binaryConverter, int numRecordsPerBlock) {
+  public static int getNumRecordsPerBlock(Configuration conf) {
+    return conf.getInt(NUM_RECORDS_PER_BLOCK, DEFAULT_NUM_RECORDS_PER_BLOCK);
+  }
+
+  public BinaryBlockWriter(OutputStream out, Class<M> protoClass, BinaryConverter<M> binaryConverter, int numRecordsPerBlock) {
     out_ = out;
     numRecordsPerBlock_ = numRecordsPerBlock;
     innerClass_ = protoClass;

--- a/core/src/main/java/com/twitter/elephantbird/mapreduce/io/RawBlockWriter.java
+++ b/core/src/main/java/com/twitter/elephantbird/mapreduce/io/RawBlockWriter.java
@@ -11,4 +11,9 @@ public class RawBlockWriter extends BinaryBlockWriter<byte[]> {
     super(out, byte[].class,
         new IdentityBinaryConverter(), DEFAULT_NUM_RECORDS_PER_BLOCK);
   }
+
+  public RawBlockWriter(OutputStream out, int numRecordsPerBlock) {
+    super(out, byte[].class,
+        new IdentityBinaryConverter(), numRecordsPerBlock);
+  }
 }

--- a/core/src/main/java/com/twitter/elephantbird/mapreduce/output/LzoBinaryBlockOutputFormat.java
+++ b/core/src/main/java/com/twitter/elephantbird/mapreduce/output/LzoBinaryBlockOutputFormat.java
@@ -2,11 +2,14 @@ package com.twitter.elephantbird.mapreduce.output;
 
 import java.io.IOException;
 
+import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.mapreduce.RecordWriter;
 import org.apache.hadoop.mapreduce.TaskAttemptContext;
 
+import com.twitter.elephantbird.mapreduce.io.BinaryBlockWriter;
 import com.twitter.elephantbird.mapreduce.io.RawBlockWriter;
 import com.twitter.elephantbird.mapreduce.io.RawBytesWritable;
+import com.twitter.elephantbird.util.HadoopCompat;
 
 /**
  * Output format for LZO block-compressed byte[] records.
@@ -19,7 +22,8 @@ public class LzoBinaryBlockOutputFormat extends LzoOutputFormat<byte[], RawBytes
   @Override
   public RecordWriter<byte[], RawBytesWritable> getRecordWriter(TaskAttemptContext job)
       throws IOException, InterruptedException {
+    Configuration conf = HadoopCompat.getConfiguration(job);
     return new LzoBinaryBlockRecordWriter<byte[], RawBytesWritable>(new RawBlockWriter(
-        getOutputStream(job)));
+        getOutputStream(job), BinaryBlockWriter.getNumRecordsPerBlock(conf)));
   }
 }

--- a/core/src/main/java/com/twitter/elephantbird/mapreduce/output/LzoGenericBlockOutputFormat.java
+++ b/core/src/main/java/com/twitter/elephantbird/mapreduce/output/LzoGenericBlockOutputFormat.java
@@ -50,8 +50,9 @@ public class LzoGenericBlockOutputFormat<M> extends LzoOutputFormat<M, GenericWr
     }
 
     BinaryConverter<?> converter = converterProvider.getConverter(conf);
+    int numRecordsPerBlock = BinaryBlockWriter.getNumRecordsPerBlock(conf);
 
     return new LzoBinaryBlockRecordWriter<M, GenericWritable<M>>(new BinaryBlockWriter(
-        getOutputStream(job), valueClass, converter));
+        getOutputStream(job), valueClass, converter, numRecordsPerBlock));
   }
 }

--- a/core/src/main/java/com/twitter/elephantbird/mapreduce/output/LzoProtobufBlockOutputFormat.java
+++ b/core/src/main/java/com/twitter/elephantbird/mapreduce/output/LzoProtobufBlockOutputFormat.java
@@ -2,6 +2,7 @@ package com.twitter.elephantbird.mapreduce.output;
 
 import java.io.IOException;
 
+import com.twitter.elephantbird.mapreduce.io.BinaryBlockWriter;
 import com.twitter.elephantbird.util.HadoopCompat;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.mapreduce.RecordWriter;
@@ -52,11 +53,13 @@ public class LzoProtobufBlockOutputFormat<M extends Message> extends LzoOutputFo
   @Override
   public RecordWriter<M, ProtobufWritable<M>> getRecordWriter(TaskAttemptContext job)
   throws IOException, InterruptedException {
+    Configuration conf = HadoopCompat.getConfiguration(job);
     if (typeRef_ == null) { // i.e. if not set by a subclass
-      typeRef_ = Protobufs.getTypeRef(HadoopCompat.getConfiguration(job), LzoProtobufBlockOutputFormat.class);
+      typeRef_ = Protobufs.getTypeRef(conf, LzoProtobufBlockOutputFormat.class);
     }
+    int numRecordsPerBlock = BinaryBlockWriter.getNumRecordsPerBlock(conf);
 
     return new LzoBinaryBlockRecordWriter<M, ProtobufWritable<M>>(
-        new ProtobufBlockWriter<M>(getOutputStream(job), typeRef_.getRawClass()));
+        new ProtobufBlockWriter<M>(getOutputStream(job), typeRef_.getRawClass(), numRecordsPerBlock));
   }
 }

--- a/core/src/main/java/com/twitter/elephantbird/mapreduce/output/LzoThriftBlockOutputFormat.java
+++ b/core/src/main/java/com/twitter/elephantbird/mapreduce/output/LzoThriftBlockOutputFormat.java
@@ -2,6 +2,7 @@ package com.twitter.elephantbird.mapreduce.output;
 
 import java.io.IOException;
 
+import com.twitter.elephantbird.mapreduce.io.BinaryBlockWriter;
 import com.twitter.elephantbird.mapreduce.io.ThriftBlockWriter;
 import com.twitter.elephantbird.mapreduce.io.ThriftWritable;
 import com.twitter.elephantbird.util.HadoopCompat;
@@ -42,10 +43,13 @@ public class LzoThriftBlockOutputFormat<M extends TBase<?, ?>>
 
   public RecordWriter<M, ThriftWritable<M>> getRecordWriter(TaskAttemptContext job)
       throws IOException, InterruptedException {
+    Configuration conf = HadoopCompat.getConfiguration(job);
     if (typeRef_ == null) {
       typeRef_ = ThriftUtils.getTypeRef(HadoopCompat.getConfiguration(job), LzoThriftBlockOutputFormat.class);
     }
+    int numRecordsPerBlock = BinaryBlockWriter.getNumRecordsPerBlock(conf);
+
     return new LzoBinaryBlockRecordWriter<M, ThriftWritable<M>>(
-        new ThriftBlockWriter<M>(getOutputStream(job), typeRef_.getRawClass()));
+        new ThriftBlockWriter<M>(getOutputStream(job), typeRef_.getRawClass(), numRecordsPerBlock));
   }
 }


### PR DESCRIPTION
@isnotinvain 
Attempt to make numRecordsPerBlock configurable.

When testing locally there's a strange failure for pig even when building from master (at line 166 of TestThriftToPig.java):
```
Failed tests:   test(com.twitter.elephantbird.pig.util.TestThriftToPig): expected:<...,{(1),(2),(3)})}-{({[}),({(and a one),(and a two)}),({(then a one, two),(three!),(FOUR!!)})}-{zero={}, three={}, two={(1,Wait.),(2,What?)]}}> but was:<...,{(1),(2),(3)})}-{({[(and a one),(and a two)}),({}),({(then a one, two),(three!),(FOUR!!)})}-{zero={}, two={(1,Wait.),(2,What?)}, three={]}}>
```

Passed all tests before this failure.