### PR TITLE
Set protobuf serde struct field name to all lower case

### DIFF
--- a/hive/src/main/java/com/twitter/elephantbird/hive/serde/ProtobufStructObjectInspector.java
+++ b/hive/src/main/java/com/twitter/elephantbird/hive/serde/ProtobufStructObjectInspector.java
@@ -34,7 +34,7 @@ public final class ProtobufStructObjectInspector extends SettableStructObjectIns
 
     @Override
     public String getFieldName() {
-      return fieldDescriptor.getName();
+      return fieldDescriptor.getName().toLowerCase();
     }
 
     @Override

--- a/hive/src/test/java/com/twitter/elephantbird/hive/serde/ProtobufDeserializerTest.java
+++ b/hive/src/test/java/com/twitter/elephantbird/hive/serde/ProtobufDeserializerTest.java
@@ -122,7 +122,7 @@ public class ProtobufDeserializerTest {
     assertEquals(protobufOI.getTypeName(),
         "struct<person:array<"
             + "struct<name:string,id:int,email:string,"
-            + "phone:array<struct<number:string,type:string>>>>,byteData:binary>");
+            + "phone:array<struct<number:string,type:string>>>>,bytedata:binary>");
   }
 
   @Test


### PR DESCRIPTION
Per the javadoc of StructField.getFieldName() in hive, the returned field name of a hive struct should be in all lowercase. If the protobuf message contains fields that contain mixed case characters, then this method could return mixed case strings.

There is a bug associated with elephant-bird returning mixed case field names. Say we have this protobuf:

```proto
message Foo {
    optional int myField = 1;
}
```

And we create a hive table **with partitioning** as follows
```sql
hive> create table elephant_bird_test
    > row format serde "com.twitter.elephantbird.hive.serde.ProtobufDeserializer"
    > partition by (
    >     `some_int` int)
    > with serdeproperties (
    > "serialization.class"="com.example.proto$Foo")
    > stored as inputformat
    >   'org.apache.hadoop.mapred.SequenceFileInputFormat'
    > OUTPUTFORMAT
    >   'org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat'
    > ;
```

If we ask Hive to describe the table we see that the column has mixed cases:

```sql
hive> desc elephant_bird_test;
OK
myField        	        int              	from deserializer


# Partition Information
# col_name            	data_type           	comment

some_int             int
```

Hive columns and struct fields, however, are case _insensitive_. So when attempting to select `myField`, Hive would lower case the column in the select statement to `myfield` and then blow up because the name of the field reported by the serde is `myField` not `myfield`:

```sql
hive> select myField
    > from elephant_bird_test
    > where some_int=0;

FAILED: RuntimeException java.lang.RuntimeException: cannot find field myfield from [org.apache.hadoop.hive.serde2.objectinspector.UnionStructObjectInspector$MyField@67bf0480, org.apache.hadoop.hive.serde2.objectinspector.UnionStructObjectInspector$MyField@5503de1, org.apache.hadoop.hive.serde2.objectinspector.UnionStructObjectInspector$MyField@32faa16c, org.apache.hadoop.hive.serde2.objectinspector.UnionStructObjectInspector$MyField@343fddd9, org.apache.hadoop.hive.serde2.objectinspector.UnionStructObjectInspector$MyField@2bbb44da, org.apache.hadoop.hive.serde2.objectinspector.UnionStructObjectInspector$MyField@2f80cb79, org.apache.hadoop.hive.serde2.objectinspector.UnionStructObjectInspector$MyField@4816ee24]
```

This issue no longer exists if we make the protobuf serde return only lower case field names.