### PR TITLE
Add an option to disable using LZO index files when computing splits

### DIFF
--- a/core/src/test/java/com/twitter/elephantbird/mapreduce/input/TestLzoTextInputFormat.java
+++ b/core/src/test/java/com/twitter/elephantbird/mapreduce/input/TestLzoTextInputFormat.java
@@ -126,10 +126,29 @@ public class TestLzoTextInputFormat {
     runTest(false, OUTPUT_SMALL, true);
   }
 
+  @Test
+  public void testIgnoreIndex() throws NoSuchAlgorithmException, IOException, InterruptedException {
+    runTest(true, OUTPUT_BIG, false, false);
+    runTest(true, OUTPUT_SMALL, false, false);
+  }
+
+  @Test
+  public void testCombineAndIgnoreIndex() throws NoSuchAlgorithmException, IOException,
+          InterruptedException {
+    runTest(true, OUTPUT_BIG, true, false);
+    runTest(true, OUTPUT_SMALL, true, false);
+  }
+
   private void runTest(boolean testWithIndex, int charsToOutput) throws IOException,
           NoSuchAlgorithmException, InterruptedException {
     runTest(testWithIndex, charsToOutput, false);
   }
+
+  private void runTest(boolean testWithIndex, int charsToOutput, boolean combineSplits)
+      throws IOException, NoSuchAlgorithmException, InterruptedException {
+    runTest(testWithIndex, charsToOutput, combineSplits, true);
+  }
+
 
   /**
    * Generate random data, compress it, index and md5 hash the data.
@@ -141,8 +160,8 @@ public class TestLzoTextInputFormat {
    * @throws NoSuchAlgorithmException
    * @throws InterruptedException
    */
-  private void runTest(boolean testWithIndex, int charsToOutput, boolean combineSplits) throws IOException,
-      NoSuchAlgorithmException, InterruptedException {
+  private void runTest(boolean testWithIndex, int charsToOutput, boolean combineSplits,
+      boolean useIndexes) throws IOException, NoSuchAlgorithmException, InterruptedException {
 
     Configuration conf = new Configuration();
     conf.setLong("fs.local.block.size", charsToOutput / 2);
@@ -182,10 +201,11 @@ public class TestLzoTextInputFormat {
     }
 
     TextInputFormat.setInputPaths(job, outputDir_);
+    LzoInputFormat.setUseLzoIndexFiles(job.getConfiguration(), useIndexes);
 
     List<InputSplit> is = inputFormat.getSplits(job);
     //verify we have the right number of lzo chunks
-    if (testWithIndex && OUTPUT_BIG == charsToOutput) {
+    if (testWithIndex && OUTPUT_BIG == charsToOutput && useIndexes) {
       assertEquals(3, is.size());
     } else {
       assertEquals(1, is.size());


### PR DESCRIPTION
We have many jobs that read large (>10,000) numbers of LZO input files.  Because of the linear relationship of split calculation time to the number of inputs, some of these jobs can actually take longer to calculate the splits than for the mappers to actually run.

Results from an trivial test job show a massive speedup when disabling using indexes when calculating splits, with no change in the number of splits actually created.

With index files enabled:
``` 
 * RESULTS:          1
 *   input paths:  9708
 *   total splits: 4854
 *   time [s]:      165
```
and disabled:
```
 *  RESULTS:          1
 *   total paths:  9708
 *   total splits: 4854
 *   time [s]:        2
```

Internally we've been using hacky similar solution which involved overriding `getSplits()` from `MultiInputFormat` in a subclass.  While hacky, it has enabled a very significant speed up in many of our jobs.

As a follow up enhancement, we could automatically skip split calculation using LZO indexes if the number of input files is greater than some number N (which could be chosen via sampling many existing jobs).

Finally, another reason one would want to enable this feature is in cloud environments.  Typically cloud blob stores (S3, GCS) have a significantly higher time-to-first-byte than say, locally hosted HDFS.  Because of this, doing many small (LZO index files are typically only a few MB) sequential reads can be very slow.  I specifically ran into this running a job in Google Dataproc processing ~10,000 files, the time to calculate splits for the job took over 40 minutes!  Disabling splitting dropped the time to ~1 second.