### PR TITLE
Update default libthrift to 0.10 and bring back corruption protection

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,34 +6,22 @@ before_install:
 # https://github.com/travis-ci/travis-ci/issues/1484
   - echo "127.0.0.1 " `hostname` | sudo tee /etc/hosts
   - sudo apt-get update -qq
-  - sudo apt-get install -qq protobuf-compiler
-  - sudo apt-get install -qq libboost-dev libboost-test-dev libboost-program-options-dev libevent-dev automake libtool flex bison pkg-config g++ libssl-dev
-  - git clone https://git-wip-us.apache.org/repos/asf/thrift.git
-  - cd thrift
-  - git checkout $THRIFT_TAG
-  - ./bootstrap.sh
-  - ./configure --disable-gen-erl --disable-gen-hs --without-ruby --without-haskell --without-erlang
-  - sudo make install
-  - cd ..
-  - sudo apt-get -qq install lzop liblzo2-dev # libzo2-dev for compiling hadoop-lzo
-  - git clone git://github.com/twitter/hadoop-lzo.git # for native libgplcompression
-  - cd hadoop-lzo
-  - git checkout master
-  - mvn compile
-  - mv target/native/Linux-* ../hadoop-lzo-native
-  - cd ..
+  - ./release.sh -c travis -t $TEMP_DIR
 
 install: true
+
+env:
+  - TEMP_DIR=$(mktemp -d)
 
 matrix:
   include:
     - jdk: openjdk7
-      env: THRIFT_TAG=0.7.0 THRIFT_PROFILE=-Pthrift7
+      env: THRIFT_TAG=0.7.0 THRIFT_PROFILE=-Pthrift7 THRIFT_PATH=thrift7
     - jdk: openjdk7
-      env: THRIFT_TAG=0.7.0 THRIFT_PROFILE=-Pthrift7 HADOOP_PROFILE=-Phadoop2
+      env: THRIFT_TAG=0.7.0 THRIFT_PROFILE=-Pthrift7 HADOOP_PROFILE=-Phadoop2 THRIFT_PATH=thrift7
     - jdk: openjdk7
-      env: THRIFT_TAG=0.9.1 THRIFT_PROFILE=-Pthrift9
+      env: THRIFT_TAG=0.10.0 THRIFT_PROFILE=-Pthrift9 THRIFT_PATH=thrift9
     - jdk: openjdk7
-      env: THRIFT_TAG=0.9.1 THRIFT_PROFILE=-Pthrift9 HADOOP_PROFILE=-Phadoop2
+      env: THRIFT_TAG=0.10.0 THRIFT_PROFILE=-Pthrift9 HADOOP_PROFILE=-Phadoop2 THRIFT_PATH=thrift9
 
-script: "mvn test -Dtest.library.path=$PWD/hadoop-lzo-native/lib -Drequire.lzo.tests=true $HADOOP_PROFILE $THRIFT_PROFILE"
+script: "mvn test -Dtest.library.path=/tmp/hadoop-lzo-native/lib -Drequire.lzo.tests=true $HADOOP_PROFILE $THRIFT_PROFILE -Dthrift.executable=$TEMP_DIR/$THRIFT_PATH/bin/thrift"

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,22 +6,8 @@ before_install:
 # https://github.com/travis-ci/travis-ci/issues/1484
   - echo "127.0.0.1 " `hostname` | sudo tee /etc/hosts
   - sudo apt-get update -qq
-  - ./release.sh -c travis -t $TEMP_DIR
 
 install: true
+jdk: openjdk7
 
-env:
-  - TEMP_DIR=$(mktemp -d)
-
-matrix:
-  include:
-    - jdk: openjdk7
-      env: THRIFT_TAG=0.7.0 THRIFT_PROFILE=-Pthrift7 THRIFT_PATH=thrift7
-    - jdk: openjdk7
-      env: THRIFT_TAG=0.7.0 THRIFT_PROFILE=-Pthrift7 HADOOP_PROFILE=-Phadoop2 THRIFT_PATH=thrift7
-    - jdk: openjdk7
-      env: THRIFT_TAG=0.10.0 THRIFT_PROFILE=-Pthrift9 THRIFT_PATH=thrift9
-    - jdk: openjdk7
-      env: THRIFT_TAG=0.10.0 THRIFT_PROFILE=-Pthrift9 HADOOP_PROFILE=-Phadoop2 THRIFT_PATH=thrift9
-
-script: "mvn test -Dtest.library.path=/tmp/hadoop-lzo-native/lib -Drequire.lzo.tests=true $HADOOP_PROFILE $THRIFT_PROFILE -Dthrift.executable=$TEMP_DIR/$THRIFT_PATH/bin/thrift"
+script: "./release.sh -c travis"

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,15 @@ before_install:
   - sudo apt-get update -qq
 
 install: true
-jdk: openjdk7
+matrix:
+  include:
+    - jdk: openjdk7
+      env: THRIFT_TAG=0.7.0
+    - jdk: openjdk7
+      env: THRIFT_TAG=0.7.0 HADOOP_PROFILE=-Phadoop2
+    - jdk: openjdk7
+      env: THRIFT_TAG=0.10.0
+    - jdk: openjdk7
+      env: THRIFT_TAG=0.10.0 HADOOP_PROFILE=-Phadoop2
 
 script: "./release.sh -c travis"

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -68,9 +68,6 @@
   <profiles>
     <profile>
       <id>thrift7</id>
-      <activation>
-        <activeByDefault>true</activeByDefault>
-      </activation>
       <build>
         <plugins>
           <plugin>
@@ -108,6 +105,9 @@
     </profile>
     <profile>
       <id>thrift9</id>
+      <activation>
+        <activeByDefault>true</activeByDefault>
+      </activation>
       <build>
         <plugins>
           <plugin>
@@ -126,6 +126,19 @@
                   </sources>
                 </configuration>
               </execution>
+              <execution>
+                <id>add-test-source</id>
+                <phase>generate-test-sources</phase>
+                <goals>
+                  <goal>add-test-source</goal>
+                </goals>
+                <configuration>
+                  <sources>
+                    <source>thrift9/src/test/java</source>
+                  </sources>
+                </configuration>
+              </execution>
+
             </executions>
           </plugin>
           <plugin>
@@ -159,8 +172,8 @@
       </plugin>
       <!-- thrift -->
       <plugin>
-        <groupId>org.apache.thrift.tools</groupId>
-        <artifactId>maven-thrift-plugin</artifactId>
+        <groupId>org.apache.thrift</groupId>
+        <artifactId>thrift-maven-plugin</artifactId>
         <executions>
           <execution>
             <id>thrift-test-sources</id>

--- a/core/src/main/java/com/twitter/elephantbird/thrift/ThriftBinaryDeserializer.java
+++ b/core/src/main/java/com/twitter/elephantbird/thrift/ThriftBinaryDeserializer.java
@@ -29,9 +29,9 @@ public class ThriftBinaryDeserializer extends AbstractThriftBinaryDeserializer {
   public ThriftBinaryDeserializer() {
     super(new ThriftBinaryProtocol.Factory());
   }
-  // set the default limit of 100M to check against corruption. In reality no single record
+  // set the default limit of 10M to check against corruption. In reality no single record
   // or container should hit this limit.
-  private long lengthLimit = 100*1024*1024;
+  private long lengthLimit = 10*1024*1024;
 
   // use protocol and transport directly instead of using ones in TDeserializer
   private final TMemoryInputTransport trans = new TMemoryInputTransport();
@@ -47,10 +47,10 @@ public class ThriftBinaryDeserializer extends AbstractThriftBinaryDeserializer {
    */
   public void deserialize(TBase base, byte[] bytes, int offset, int len) throws TException {
 
-    // If incoming payload is larger than threshold then double the threshold and
-    // re-initialize object. This generally should not happen.
+    // If incoming payload is larger than threshold then adjust the threshold by making it 10% more
+    // than incoming payload-length and re-initialize object. This generally should not happen.
     if (len > lengthLimit) {
-      lengthLimit *= 2;
+      lengthLimit = len + Double.valueOf(0.1 * len).longValue();
       protocol = new ThriftBinaryProtocol(trans, lengthLimit, lengthLimit);
     }
 

--- a/core/src/main/java/com/twitter/elephantbird/thrift/ThriftBinaryDeserializer.java
+++ b/core/src/main/java/com/twitter/elephantbird/thrift/ThriftBinaryDeserializer.java
@@ -49,7 +49,7 @@ public class ThriftBinaryDeserializer extends AbstractThriftBinaryDeserializer {
 
     // If incoming payload is larger than threshold then double the threshold and
     // re-initialize object. This generally should not happen.
-    if (bytes.length > lengthLimit) {
+    if (len > lengthLimit) {
       lengthLimit *= 2;
       protocol = new ThriftBinaryProtocol(trans, lengthLimit, lengthLimit);
     }

--- a/core/src/main/java/com/twitter/elephantbird/thrift/ThriftBinaryDeserializer.java
+++ b/core/src/main/java/com/twitter/elephantbird/thrift/ThriftBinaryDeserializer.java
@@ -26,10 +26,6 @@ import org.apache.thrift.transport.TMemoryInputTransport;
  */
 public class ThriftBinaryDeserializer extends AbstractThriftBinaryDeserializer {
 
-  // use protocol and transport directly instead of using ones in TDeserializer
-  private final TMemoryInputTransport trans = new TMemoryInputTransport();
-  private final TBinaryProtocol protocol = new ThriftBinaryProtocol(trans);
-
   public ThriftBinaryDeserializer() {
     super(new ThriftBinaryProtocol.Factory());
   }
@@ -43,6 +39,11 @@ public class ThriftBinaryDeserializer extends AbstractThriftBinaryDeserializer {
    * Same as {@link #deserialize(TBase, byte[])}, but much more buffer copy friendly.
    */
   public void deserialize(TBase base, byte[] bytes, int offset, int len) throws TException {
+
+    // use protocol and transport directly instead of using ones in TDeserializer
+    TMemoryInputTransport trans = new TMemoryInputTransport();
+    TBinaryProtocol protocol = new ThriftBinaryProtocol(trans, bytes.length, bytes.length);
+
     resetAndInitialize(protocol, len);
     trans.reset(bytes, offset, len);
     base.read(protocol);

--- a/core/src/main/java/com/twitter/elephantbird/thrift/ThriftBinaryProtocol.java
+++ b/core/src/main/java/com/twitter/elephantbird/thrift/ThriftBinaryProtocol.java
@@ -26,6 +26,10 @@ public class ThriftBinaryProtocol extends AbstractThriftBinaryProtocol {
     super(trans);
   }
 
+  ThriftBinaryProtocol(TTransport trans, long stringLengthLimit, long containerLengthLimit) {
+    super(trans, stringLengthLimit, containerLengthLimit);
+  }
+
   /**
    * Ensures that an element type in a for container (List, Set, Map) is
    * a valid container.

--- a/core/thrift7/src/main/java/com/twitter/elephantbird/thrift/AbstractThriftBinaryProtocol.java
+++ b/core/thrift7/src/main/java/com/twitter/elephantbird/thrift/AbstractThriftBinaryProtocol.java
@@ -19,6 +19,11 @@ abstract class AbstractThriftBinaryProtocol extends TBinaryProtocol {
     super(trans, strictRead, strictWrite);
   }
 
+  @SuppressWarnings("unused")
+  public AbstractThriftBinaryProtocol(TTransport trans, long stringLengthLimit, long containerLengthLimit) {
+    super(trans);
+  }
+
   protected void resetAndInitialize(TBinaryProtocol protocol, int newLength) {
     protocol.reset();
     protocol.setReadLength(newLength);

--- a/core/thrift9/src/main/java/com/twitter/elephantbird/thrift/AbstractThriftBinaryProtocol.java
+++ b/core/thrift9/src/main/java/com/twitter/elephantbird/thrift/AbstractThriftBinaryProtocol.java
@@ -15,6 +15,10 @@ abstract class AbstractThriftBinaryProtocol extends TBinaryProtocol {
     super(trans);
   }
 
+  public AbstractThriftBinaryProtocol(TTransport trans, long stringLengthLimit, long containerLengthLimit) {
+    super(trans, stringLengthLimit, containerLengthLimit);
+  }
+
   /**
    * Check if the container size is valid.
    */

--- a/core/thrift9/src/test/java/com/twitter/elephantbird/thrift/TestThrift9BinaryProtocol.java
+++ b/core/thrift9/src/test/java/com/twitter/elephantbird/thrift/TestThrift9BinaryProtocol.java
@@ -1,0 +1,69 @@
+package com.twitter.elephantbird.thrift;
+
+import org.apache.thrift.TException;
+import org.apache.thrift.protocol.TProtocolException;
+import org.apache.thrift.transport.TTransport;
+import org.junit.Test;
+
+import static org.easymock.EasyMock.replay;
+import static org.easymock.EasyMock.verify;
+
+public class TestThrift9BinaryProtocol extends TestThriftBinaryProtocol {
+
+  int METADATA_BYTES = 5; // type(1) + size(4)
+  int MAP_METADATA_BYTES = 6; // key type(1) + value type(1) + size(4)
+
+  @Test
+  public void testCheckContainerSizeValidWhenCheckReadLength() throws TException {
+    TTransport transport;
+    ThriftBinaryProtocol protocol;
+
+    transport = getMockTransport(3);
+    replay(transport);
+    protocol = new ThriftBinaryProtocol(transport, METADATA_BYTES + 3, METADATA_BYTES + 3);
+    protocol.readListBegin();
+    verify(transport);
+
+    transport = getMockTransport(3);
+    replay(transport);
+    protocol = new ThriftBinaryProtocol(transport, METADATA_BYTES + 3, METADATA_BYTES + 3);
+    protocol.readSetBegin();
+    verify(transport);
+
+    transport = getMockMapTransport(3);
+    replay(transport);
+    protocol = new ThriftBinaryProtocol(transport, METADATA_BYTES + 3, METADATA_BYTES + 3);
+    protocol.readMapBegin();
+    verify(transport);
+  }
+
+  @Test(expected=TProtocolException.class)
+  public void testCheckListContainerSizeInvalidWhenCheckReadLength() throws TException {
+    TTransport transport = getMockTransport(400);
+    replay(transport);
+    ThriftBinaryProtocol protocol = new ThriftBinaryProtocol(transport, METADATA_BYTES + 3, METADATA_BYTES + 3);
+    // this throws because size returned by Transport (400) > size per readLength (3)
+    protocol.readListBegin();
+    verify(transport);
+  }
+
+  @Test(expected=TProtocolException.class)
+  public void testCheckSetContainerSizeInvalidWhenCheckReadLength() throws TException {
+    TTransport transport = getMockTransport(400);
+    replay(transport);
+    ThriftBinaryProtocol protocol = new ThriftBinaryProtocol(transport, METADATA_BYTES + 3, METADATA_BYTES + 3);
+    // this throws because size returned by Transport (400) > size per readLength (3)
+    protocol.readSetBegin();
+    verify(transport);
+  }
+
+  @Test(expected=TProtocolException.class)
+  public void testCheckMapContainerSizeInvalidWhenCheckReadLength() throws TException {
+    TTransport transport = getMockMapTransport(400);
+    replay(transport);
+    ThriftBinaryProtocol protocol = new ThriftBinaryProtocol(transport, METADATA_BYTES + 3, METADATA_BYTES + 3);
+    // this throws because size returned by Transport (400) > size per readLength (3)
+    protocol.readMapBegin();
+    verify(transport);
+  }
+}

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -53,8 +53,8 @@
       </plugin>
       <!-- thrift -->
       <plugin>
-        <groupId>org.apache.thrift.tools</groupId>
-        <artifactId>maven-thrift-plugin</artifactId>
+        <groupId>org.apache.thrift</groupId>
+        <artifactId>thrift-maven-plugin</artifactId>
         <executions>
           <execution>
             <id>thrift-sources</id>

--- a/pig/pom.xml
+++ b/pig/pom.xml
@@ -55,8 +55,8 @@
     <plugins>
       <!-- thrift -->
       <plugin>
-        <groupId>org.apache.thrift.tools</groupId>
-        <artifactId>maven-thrift-plugin</artifactId>
+        <groupId>org.apache.thrift</groupId>
+        <artifactId>thrift-maven-plugin</artifactId>
         <executions>
           <execution>
             <id>thrift-test-sources</id>

--- a/pom.xml
+++ b/pom.xml
@@ -84,7 +84,7 @@
     <protobuf.version>2.4.1</protobuf.version>
     <protoc.executable>protoc</protoc.executable>
     <hadoop-lzo.version>0.4.19</hadoop-lzo.version>
-    <thrift.version>0.7.0</thrift.version>
+    <thrift.version>0.10.0</thrift.version>
     <thrift.executable>thrift</thrift.executable>
     <cascading2.version>2.5.2</cascading2.version>
     <cascading3.version>3.0.2</cascading3.version>
@@ -424,17 +424,17 @@
     </profile>
     <profile>
       <id>thrift7</id>
-      <activation>
-        <activeByDefault>true</activeByDefault>
-      </activation>
       <properties>
         <thrift.version>0.7.0</thrift.version>
       </properties>
     </profile>
     <profile>
       <id>thrift9</id>
+      <activation>
+        <activeByDefault>true</activeByDefault>
+      </activation>
       <properties>
-        <thrift.version>0.9.1</thrift.version>
+        <thrift.version>0.10.0</thrift.version>
       </properties>
     </profile>
   </profiles>
@@ -597,9 +597,9 @@
         </plugin>
         <!-- thrift -->
         <plugin>
-          <groupId>org.apache.thrift.tools</groupId>
-          <artifactId>maven-thrift-plugin</artifactId>
-          <version>0.1.10</version>
+          <groupId>org.apache.thrift</groupId>
+          <artifactId>thrift-maven-plugin</artifactId>
+          <version>0.10.0</version>
           <configuration>
             <thriftExecutable>${thrift.executable}</thriftExecutable>
           </configuration>
@@ -656,9 +656,9 @@
                 </pluginExecution>
                 <pluginExecution>
                   <pluginExecutionFilter>
-                    <groupId>org.apache.thrift.tools</groupId>
-                    <artifactId>maven-thrift-plugin</artifactId>
-                    <versionRange>[0.1.10,)</versionRange>
+                    <groupId>org.apache.thrift</groupId>
+                    <artifactId>thrift-maven-plugin</artifactId>
+                    <versionRange>[0.10.0,)</versionRange>
                     <goals>
                       <goal>compile</goal>
                       <goal>testCompile</goal>

--- a/release.sh
+++ b/release.sh
@@ -8,17 +8,18 @@ sudo apt-get -qq install xmlstarlet maven
 # Global default vars used in this script
 ######################################################################################
 BASE_DIR=$PWD
-WORK_DIR=/tmp/elephant-bird_release
+TEMP_DIR=$(mktemp -d)
+WORK_DIR=$TEMP_DIR/elephant-bird_release
 COMMAND="release"
 ACTUAL_VERSION=$(xmlstarlet sel -t -v "/_:project/_:version" pom.xml)
 RELEASE_VERSION=$(echo $ACTUAL_VERSION|sed 's/-SNAPSHOT//')
 BASE_BRANCH=$(git rev-parse --abbrev-ref HEAD)
 DIRTY_SCM=false
 GIT_REPO=git@github.com:twitter/elephant-bird.git
-THRIFT7_PATH="/tmp/thrift7"
-THRIFT9_PATH="/tmp/thrift9"
-HADOOP_LZO_PATH="/tmp/hadoop-lzo-native"
-PROTOBUF_PATH="/tmp/protobuf"
+THRIFT7_PATH="$TEMP_DIR/thrift7"
+THRIFT9_PATH="$TEMP_DIR/thrift9"
+HADOOP_LZO_PATH="$TEMP_DIR/hadoop-lzo-native"
+PROTOBUF_PATH="$TEMP_DIR/protobuf"
 
 ######################################################################################
 
@@ -28,6 +29,14 @@ key="$1"
 case $key in
     -c|--command)
       COMMAND="$2"
+      ;;
+    -t|--temp-dir)
+      TEMP_DIR="$2"
+      WORK_DIR=$TEMP_DIR/elephant-bird_release
+      THRIFT7_PATH="$TEMP_DIR/thrift7"
+      THRIFT9_PATH="$TEMP_DIR/thrift9"
+      HADOOP_LZO_PATH="$TEMP_DIR/hadoop-lzo-native"
+      PROTOBUF_PATH="$TEMP_DIR/protobuf"
       ;;
     -r|--release-version)
       RELEASE_VERSION="$2"
@@ -42,7 +51,7 @@ case $key in
       echo "Unknown parameter $key"
       echo "Usage: ./release.sh [OPTION]
 -c,--comand commandName
-    possible values test|install|deploy|release
+    possible values travis|test|install|deploy|release
 -r,--release-version versionNumber
     will be used to deploy the artifacts and make the release branch
 -n,--next-version versionNumber
@@ -109,37 +118,49 @@ function prepareFromRemote {
 
 
 # Install deps required to build and run native thrift
-function installNativeThrift {
+function installNativeThrift7 {
   local CURR_DIR=$PWD
 
-  if [ ! -d $THRIFT7_PATH ] || [ ! -d $THRIFT9_PATH ]; then
-    cd /tmp
+  if [ ! -d $THRIFT7_PATH ]; then
+    cd $TEMP_DIR
     sudo apt-get install -qq libboost-dev libboost-test-dev libboost-program-options-dev libevent-dev automake libtool flex bison pkg-config g++ libssl-dev
     git clone https://git-wip-us.apache.org/repos/asf/thrift.git
     cd thrift
 
-    if [ ! -d $THRIFT7_PATH ]; then
-      git checkout 0.7.0
-      ./bootstrap.sh
-      ./configure --disable-gen-erl --disable-gen-hs --without-ruby --without-haskell --without-python --without-erlang --prefix=$THRIFT7_PATH JAVA_PREFIX=$THRIFT7_PATH/lib/
+    git checkout 0.7.0
+    ./bootstrap.sh
+    ./configure --disable-gen-erl --disable-gen-hs --without-ruby --without-haskell --without-python --without-erlang --prefix=$THRIFT7_PATH JAVA_PREFIX=$THRIFT7_PATH/lib/
 
-      # See https://issues.apache.org/jira/browse/THRIFT-1614 a solution would be to use two different versions of automake
-      # but this would be more complex. The other option is to change the include in thriftl.cc but I don't like that much either.
-      set +e
-      make install > /dev/null 2>&1
-      set -e
-      mv compiler/cpp/thrifty.hh compiler/cpp/thrifty.h
+    # See https://issues.apache.org/jira/browse/THRIFT-1614 a solution would be to use two different versions of automake
+    # but this would be more complex. The other option is to change the include in thriftl.cc but I don't like that much either.
+    set +e
+    make install > /dev/null 2>&1
+    set -e
+    mv compiler/cpp/thrifty.hh compiler/cpp/thrifty.h
 
-      make install
-      make clean
-    fi
+    make install
+    make clean
 
-    if [ ! -d $THRIFT9_PATH ]; then
-      git checkout 0.10.0
-      ./bootstrap.sh
-      ./configure --disable-gen-erl --disable-gen-hs --without-ruby --without-haskell --without-python --without-erlang --prefix=$THRIFT9_PATH JAVA_PREFIX=$THRIFT9_PATH/lib/
-      make install
-    fi
+    cd ..
+    rm -Rf thrift
+  fi
+
+  cd $CURR_DIR
+}
+
+function installNativeThrift9 {
+  local CURR_DIR=$PWD
+
+  if [ ! -d $THRIFT9_PATH ]; then
+    cd $TEMP_DIR
+    sudo apt-get install -qq libboost-dev libboost-test-dev libboost-program-options-dev libevent-dev automake libtool flex bison pkg-config g++ libssl-dev
+    git clone https://git-wip-us.apache.org/repos/asf/thrift.git
+    cd thrift
+
+    git checkout 0.10.0
+    ./bootstrap.sh
+    ./configure --disable-gen-erl --disable-gen-hs --without-ruby --without-haskell --without-python --without-erlang --prefix=$THRIFT9_PATH JAVA_PREFIX=$THRIFT9_PATH/lib/
+    make install
 
     cd ..
     rm -Rf thrift
@@ -152,7 +173,7 @@ function installProtobuf {
   local CURR_DIR=$PWD
 
   if [ ! -d $PROTOBUF_PATH ]; then
-    cd /tmp
+    cd $TEMP_DIR
     wget https://github.com/google/protobuf/releases/download/v2.4.1/protobuf-2.4.1.tar.gz -O - | tar -xz
     cd protobuf-2.4.1
     ./configure --prefix=$PROTOBUF_PATH
@@ -175,7 +196,7 @@ function installHadoopLzo {
       read JAVA_HOME
     fi
 
-    cd /tmp
+    cd $TEMP_DIR
     sudo apt-get -qq install lzop liblzo2-dev
     git clone git://github.com/twitter/hadoop-lzo.git
     cd hadoop-lzo
@@ -198,11 +219,21 @@ __MVN_HADOOP_LZO="-Dtest.library.path=$HADOOP_LZO_PATH/lib -Drequire.lzo.tests=t
 __MVN_PROTOC_EXECUTABLE="-Dprotoc.executable=$PROTOBUF_PATH/bin/protoc"
 
 case "$COMMAND" in
+"travis")
+    if [ $THRIFT_TAG == "0.7.0" ]; then
+        installNativeThrift7
+    else
+        installNativeThrift9
+    fi
+    installHadoopLzo
+    installProtobuf
+    ;;
 "test")
     prepareFromLocal
     git checkout $BASE_BRANCH
 
-    installNativeThrift
+    installNativeThrift7
+    installNativeThrift9
     installHadoopLzo
     installProtobuf
 
@@ -214,7 +245,8 @@ case "$COMMAND" in
     prepareFromLocal
     git checkout $BASE_BRANCH
 
-    installNativeThrift
+    installNativeThrift7
+    installNativeThrift9
     installHadoopLzo
     installProtobuf
 
@@ -226,7 +258,8 @@ case "$COMMAND" in
     prepareFromLocal
     git checkout $BASE_BRANCH
 
-    installNativeThrift
+    installNativeThrift7
+    installNativeThrift9
     installHadoopLzo
     installProtobuf
 
@@ -242,14 +275,15 @@ case "$COMMAND" in
     echo "Will run full release including: release branch, deploy artifacts and update current branch to next version"
 
     checkNoUncommitedChanges
-  
+
     # Ensure our copy is fresh
     git pull
 
     # We want to make the release from the initial branch, here we are in the working copy, not the original directory
     git checkout $BASE_BRANCH
 
-    installNativeThrift
+    installNativeThrift7
+    installNativeThrift9
     installHadoopLzo
     installProtobuf
 
@@ -284,4 +318,4 @@ case "$COMMAND" in
 esac
 
 # Cleaning after us (in case of an error we want the src to remain so we can debug things)
-rm -Rf /tmp/elephant-bird_release
+rm -Rf $TEMP_DIR

--- a/release.sh
+++ b/release.sh
@@ -135,7 +135,7 @@ function installNativeThrift {
     fi
 
     if [ ! -d $THRIFT9_PATH ]; then
-      git checkout 0.9.1
+      git checkout 0.10.0
       ./bootstrap.sh
       ./configure --disable-gen-erl --disable-gen-hs --without-ruby --without-haskell --without-python --without-erlang --prefix=$THRIFT9_PATH JAVA_PREFIX=$THRIFT9_PATH/lib/
       make install
@@ -206,8 +206,8 @@ case "$COMMAND" in
     installHadoopLzo
     installProtobuf
 
-    mvn clean test $__MVN_THRIFT7 $__MVN_HADOOP_LZO $__MVN_PROTOC_EXECUTABLE
-    mvn clean test $__MVN_THRIFT9 $__MVN_HADOOP_LZO $__MVN_PROTOC_EXECUTABLE
+    mvn clean test $__MVN_THRIFT7 $__MVN_HADOOP_LZO $__MVN_PROTOC_EXECUTABLE -X
+    mvn clean test $__MVN_THRIFT9 $__MVN_HADOOP_LZO $__MVN_PROTOC_EXECUTABLE -X
     ;;
 "install")
     echo "Will install current version"


### PR DESCRIPTION
Summary:
-- Move to libthrift 0.10 broke elephant-bird as EB was only guarding against corruption in 0.7. 
-- This fix will bring back corruption protection to libthrift 0.10 and also make it default. Change is also backward compatible so if classifier is thrift7, it will continue to work
-- Add unit-test for new version