### PR TITLE
Json parser performance boost

### DIFF
--- a/pig/pom.xml
+++ b/pig/pom.xml
@@ -38,6 +38,10 @@
       <artifactId>joda-time</artifactId>
     </dependency>
     <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-core</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.codehaus.jackson</groupId>
       <artifactId>jackson-mapper-asl</artifactId>
     </dependency>

--- a/pig/src/test/java/com/twitter/elephantbird/pig/piggybank/TestJsonStringToMap.java
+++ b/pig/src/test/java/com/twitter/elephantbird/pig/piggybank/TestJsonStringToMap.java
@@ -37,7 +37,7 @@ public class TestJsonStringToMap {
     Tuple input = tupleFactory_.newTuple(Arrays.asList("{\"name\": \"value\", \"number\": 2}"));
     Map<String, String> result = udf_.exec(input);
     assertTrue("It should return a Map", result instanceof Map<?, ?>);
-    assertEquals("value", result.get("name"));
+    assertEquals("\"value\"", result.get("name"));
     assertEquals("It is expected to return numbers as strings", "2", result.get("number"));
   }
 
@@ -76,7 +76,7 @@ public class TestJsonStringToMap {
       assertEquals(2, t.size());
       Map<?, ?> actual = (Map<?, ?>) t.get(1);
       assertNotNull(actual);
-      Map<String, String> expected = ImmutableMap.<String, String> of("name", "bob", "number", "2");
+      Map<String, String> expected = ImmutableMap.<String, String> of("name", "\"bob\"", "number", "2");
       assertEquals(expected.size(), actual.size());
       for (Map.Entry<String, String> e : expected.entrySet()) {
         assertEquals(e.getValue(), actual.get(e.getKey()));

--- a/pom.xml
+++ b/pom.xml
@@ -318,6 +318,11 @@
         <version>1.8.8</version>
         <scope>provided</scope>
       </dependency>
+      <dependency>
+        <groupId>com.fasterxml.jackson.core</groupId>
+        <artifactId>jackson-core</artifactId>
+        <version>2.7.8</version>
+      </dependency>
       <!-- hive -->
       <dependency>
         <groupId>org.apache.hive</groupId>


### PR DESCRIPTION
I have created a test that shows that the new faster xml jackson library parser API can be taken advantage of in this case (and perhaps other elephant bird cases). My tests results shows 2x speed boost for typical deeper json hierarchies. The drawback here is the upgrade of the jackson library from 1.x line to 2.x line